### PR TITLE
refactor(data)!: убрать префикс Nomad из моделей данных, роль nomad → master

### DIFF
--- a/apps/nomad-backend/prisma/migrations/20260622000000_strip_nomad_prefix/migration.sql
+++ b/apps/nomad-backend/prisma/migrations/20260622000000_strip_nomad_prefix/migration.sql
@@ -1,0 +1,85 @@
+-- Strip "Nomad" prefix from all data-model objects (tables, constraints, indexes)
+-- and migrate staff role value 'nomad' -> 'master'. Metadata-only renames (no data rewrite).
+
+-- 1) Rename tables
+ALTER TABLE "NomadAuditEvent" RENAME TO "AuditEvent";
+ALTER TABLE "NomadDailyAccessCode" RENAME TO "DailyAccessCode";
+ALTER TABLE "NomadFlavorCatalog" RENAME TO "FlavorCatalog";
+ALTER TABLE "NomadFlavorProfileCatalog" RENAME TO "FlavorProfileCatalog";
+ALTER TABLE "NomadFlavorTagCatalog" RENAME TO "FlavorTagCatalog";
+ALTER TABLE "NomadIntroCard" RENAME TO "IntroCard";
+ALTER TABLE "NomadMix" RENAME TO "Mix";
+ALTER TABLE "NomadMixComponent" RENAME TO "MixComponent";
+ALTER TABLE "NomadMixRating" RENAME TO "MixRating";
+ALTER TABLE "NomadRail" RENAME TO "Rail";
+ALTER TABLE "NomadRailMix" RENAME TO "RailMix";
+ALTER TABLE "NomadSmokeCtaEvent" RENAME TO "SmokeCtaEvent";
+ALTER TABLE "NomadSourceTagMapping" RENAME TO "SourceTagMapping";
+ALTER TABLE "NomadStaffAccount" RENAME TO "StaffAccount";
+ALTER TABLE "NomadTelegramAutomationState" RENAME TO "TelegramAutomationState";
+ALTER TABLE "NomadTelegramOperator" RENAME TO "TelegramOperator";
+ALTER TABLE "NomadTelegramRecipient" RENAME TO "TelegramRecipient";
+ALTER TABLE "NomadTobacco" RENAME TO "Tobacco";
+
+-- 2) Rename primary-key and foreign-key constraints
+ALTER TABLE "AuditEvent" RENAME CONSTRAINT "NomadAuditEvent_pkey" TO "AuditEvent_pkey";
+ALTER TABLE "DailyAccessCode" RENAME CONSTRAINT "NomadDailyAccessCode_pkey" TO "DailyAccessCode_pkey";
+ALTER TABLE "FlavorCatalog" RENAME CONSTRAINT "NomadFlavorCatalog_pkey" TO "FlavorCatalog_pkey";
+ALTER TABLE "FlavorProfileCatalog" RENAME CONSTRAINT "NomadFlavorProfileCatalog_pkey" TO "FlavorProfileCatalog_pkey";
+ALTER TABLE "FlavorTagCatalog" RENAME CONSTRAINT "NomadFlavorTagCatalog_pkey" TO "FlavorTagCatalog_pkey";
+ALTER TABLE "IntroCard" RENAME CONSTRAINT "NomadIntroCard_pkey" TO "IntroCard_pkey";
+ALTER TABLE "MixComponent" RENAME CONSTRAINT "NomadMixComponent_mixId_fkey" TO "MixComponent_mixId_fkey";
+ALTER TABLE "MixComponent" RENAME CONSTRAINT "NomadMixComponent_pkey" TO "MixComponent_pkey";
+ALTER TABLE "MixComponent" RENAME CONSTRAINT "NomadMixComponent_tobaccoId_fkey" TO "MixComponent_tobaccoId_fkey";
+ALTER TABLE "MixRating" RENAME CONSTRAINT "NomadMixRating_mixId_fkey" TO "MixRating_mixId_fkey";
+ALTER TABLE "MixRating" RENAME CONSTRAINT "NomadMixRating_pkey" TO "MixRating_pkey";
+ALTER TABLE "Mix" RENAME CONSTRAINT "NomadMix_pkey" TO "Mix_pkey";
+ALTER TABLE "RailMix" RENAME CONSTRAINT "NomadRailMix_mixId_fkey" TO "RailMix_mixId_fkey";
+ALTER TABLE "RailMix" RENAME CONSTRAINT "NomadRailMix_pkey" TO "RailMix_pkey";
+ALTER TABLE "RailMix" RENAME CONSTRAINT "NomadRailMix_railId_fkey" TO "RailMix_railId_fkey";
+ALTER TABLE "Rail" RENAME CONSTRAINT "NomadRail_pkey" TO "Rail_pkey";
+ALTER TABLE "SmokeCtaEvent" RENAME CONSTRAINT "NomadSmokeCtaEvent_mixId_fkey" TO "SmokeCtaEvent_mixId_fkey";
+ALTER TABLE "SmokeCtaEvent" RENAME CONSTRAINT "NomadSmokeCtaEvent_pkey" TO "SmokeCtaEvent_pkey";
+ALTER TABLE "SourceTagMapping" RENAME CONSTRAINT "NomadSourceTagMapping_pkey" TO "SourceTagMapping_pkey";
+ALTER TABLE "StaffAccount" RENAME CONSTRAINT "NomadStaffAccount_pkey" TO "StaffAccount_pkey";
+ALTER TABLE "TelegramAutomationState" RENAME CONSTRAINT "NomadTelegramAutomationState_pkey" TO "TelegramAutomationState_pkey";
+ALTER TABLE "TelegramOperator" RENAME CONSTRAINT "NomadTelegramOperator_pkey" TO "TelegramOperator_pkey";
+ALTER TABLE "TelegramRecipient" RENAME CONSTRAINT "NomadTelegramRecipient_pkey" TO "TelegramRecipient_pkey";
+ALTER TABLE "Tobacco" RENAME CONSTRAINT "NomadTobacco_pkey" TO "Tobacco_pkey";
+
+-- 3) Rename unique/secondary indexes
+ALTER INDEX "NomadAuditEvent_actorLogin_createdAt_idx" RENAME TO "AuditEvent_actorLogin_createdAt_idx";
+ALTER INDEX "NomadAuditEvent_createdAt_idx" RENAME TO "AuditEvent_createdAt_idx";
+ALTER INDEX "NomadAuditEvent_entityType_createdAt_idx" RENAME TO "AuditEvent_entityType_createdAt_idx";
+ALTER INDEX "NomadDailyAccessCode_active_startsAt_endsAt_idx" RENAME TO "DailyAccessCode_active_startsAt_endsAt_idx";
+ALTER INDEX "NomadIntroCard_step_key" RENAME TO "IntroCard_step_key";
+ALTER INDEX "NomadMixComponent_mixId_idx" RENAME TO "MixComponent_mixId_idx";
+ALTER INDEX "NomadMixComponent_mixId_tobaccoId_key" RENAME TO "MixComponent_mixId_tobaccoId_key";
+ALTER INDEX "NomadMixComponent_tobaccoId_idx" RENAME TO "MixComponent_tobaccoId_idx";
+ALTER INDEX "NomadMixRating_createdAt_idx" RENAME TO "MixRating_createdAt_idx";
+ALTER INDEX "NomadMixRating_mixId_idx" RENAME TO "MixRating_mixId_idx";
+ALTER INDEX "NomadRailMix_mixId_idx" RENAME TO "RailMix_mixId_idx";
+ALTER INDEX "NomadRailMix_railId_idx" RENAME TO "RailMix_railId_idx";
+ALTER INDEX "NomadRailMix_railId_mixId_key" RENAME TO "RailMix_railId_mixId_key";
+ALTER INDEX "NomadRail_active_idx" RENAME TO "Rail_active_idx";
+ALTER INDEX "NomadRail_type_idx" RENAME TO "Rail_type_idx";
+ALTER INDEX "NomadSmokeCtaEvent_mixId_idx" RENAME TO "SmokeCtaEvent_mixId_idx";
+ALTER INDEX "NomadSourceTagMapping_sourceKind_idx" RENAME TO "SourceTagMapping_sourceKind_idx";
+ALTER INDEX "NomadSourceTagMapping_sourceKind_normalizedSourceTag_key" RENAME TO "SourceTagMapping_sourceKind_normalizedSourceTag_key";
+ALTER INDEX "NomadStaffAccount_active_idx" RENAME TO "StaffAccount_active_idx";
+ALTER INDEX "NomadStaffAccount_login_key" RENAME TO "StaffAccount_login_key";
+ALTER INDEX "NomadTelegramOperator_active_idx" RENAME TO "TelegramOperator_active_idx";
+ALTER INDEX "NomadTelegramOperator_linkedChatId_idx" RENAME TO "TelegramOperator_linkedChatId_idx";
+ALTER INDEX "NomadTelegramOperator_linkedChatId_key" RENAME TO "TelegramOperator_linkedChatId_key";
+ALTER INDEX "NomadTelegramOperator_phone_key" RENAME TO "TelegramOperator_phone_key";
+ALTER INDEX "NomadTelegramRecipient_chatId_scope_key" RENAME TO "TelegramRecipient_chatId_scope_key";
+ALTER INDEX "NomadTelegramRecipient_scope_active_idx" RENAME TO "TelegramRecipient_scope_active_idx";
+ALTER INDEX "NomadTobacco_archived_idx" RENAME TO "Tobacco_archived_idx";
+ALTER INDEX "NomadTobacco_inStock_idx" RENAME TO "Tobacco_inStock_idx";
+ALTER INDEX "NomadTobacco_manufacturer_lineName_name_idx" RENAME TO "Tobacco_manufacturer_lineName_name_idx";
+ALTER INDEX "NomadTobacco_sourceExternalId_key" RENAME TO "Tobacco_sourceExternalId_key";
+ALTER INDEX "NomadTobacco_sourceKind_idx" RENAME TO "Tobacco_sourceKind_idx";
+ALTER INDEX "NomadTobacco_sourceKind_sourceNumericId_key" RENAME TO "Tobacco_sourceKind_sourceNumericId_key";
+
+-- 4) Migrate staff role value
+UPDATE "StaffAccount" SET "role" = 'master' WHERE "role" = 'nomad';

--- a/apps/nomad-backend/prisma/schema.prisma
+++ b/apps/nomad-backend/prisma/schema.prisma
@@ -7,7 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model NomadIntroCard {
+model IntroCard {
   id          String   @id
   step        Int      @unique
   title       String
@@ -17,7 +17,7 @@ model NomadIntroCard {
   updatedAt   DateTime @updatedAt
 }
 
-model NomadStaffAccount {
+model StaffAccount {
   id           String   @id
   login        String   @unique
   passwordHash String
@@ -31,7 +31,7 @@ model NomadStaffAccount {
   @@index([active])
 }
 
-model NomadDailyAccessCode {
+model DailyAccessCode {
   id        String   @id
   codeValue String
   codeHash  String
@@ -46,7 +46,7 @@ model NomadDailyAccessCode {
   @@index([active, startsAt, endsAt])
 }
 
-model NomadTelegramRecipient {
+model TelegramRecipient {
   id        String   @id
   chatId    String
   label     String
@@ -59,7 +59,7 @@ model NomadTelegramRecipient {
   @@index([scope, active])
 }
 
-model NomadTelegramOperator {
+model TelegramOperator {
   id                  String    @id
   name                String
   phone               String    @unique
@@ -77,7 +77,7 @@ model NomadTelegramOperator {
   @@index([linkedChatId])
 }
 
-model NomadTelegramAutomationState {
+model TelegramAutomationState {
   id                    String    @id
   lastHeartbeatAt       DateTime?
   lastRotateAt          DateTime?
@@ -100,7 +100,7 @@ model NomadTelegramAutomationState {
   updatedAt             DateTime  @updatedAt
 }
 
-model NomadAuditEvent {
+model AuditEvent {
   id          String   @id @default(uuid())
   actorLogin  String
   actorName   String
@@ -117,7 +117,7 @@ model NomadAuditEvent {
   @@index([actorLogin, createdAt])
 }
 
-model NomadTobacco {
+model Tobacco {
   id              String            @id
   manufacturer    String
   lineName        String            @default("")
@@ -141,7 +141,7 @@ model NomadTobacco {
   archived        Boolean           @default(false)
   createdAt       DateTime          @default(now())
   updatedAt       DateTime          @updatedAt
-  mixComponents   NomadMixComponent[]
+  mixComponents   MixComponent[]
 
   @@unique([sourceKind, sourceNumericId])
   @@index([manufacturer, lineName, name])
@@ -150,7 +150,7 @@ model NomadTobacco {
   @@index([sourceKind])
 }
 
-model NomadFlavorProfileCatalog {
+model FlavorProfileCatalog {
   key         String   @id
   label       String
   tobaccoCount Int     @default(0)
@@ -158,7 +158,7 @@ model NomadFlavorProfileCatalog {
   updatedAt   DateTime @updatedAt
 }
 
-model NomadFlavorCatalog {
+model FlavorCatalog {
   key         String   @id
   label       String
   tobaccoCount Int     @default(0)
@@ -166,7 +166,7 @@ model NomadFlavorCatalog {
   updatedAt   DateTime @updatedAt
 }
 
-model NomadFlavorTagCatalog {
+model FlavorTagCatalog {
   key         String   @id
   label       String
   tobaccoCount Int     @default(0)
@@ -174,7 +174,7 @@ model NomadFlavorTagCatalog {
   updatedAt   DateTime @updatedAt
 }
 
-model NomadSourceTagMapping {
+model SourceTagMapping {
   id                  String   @id
   sourceKind          String
   sourceTag           String
@@ -191,7 +191,7 @@ model NomadSourceTagMapping {
   @@index([sourceKind])
 }
 
-model NomadMix {
+model Mix {
   id              String            @id
   name            String
   description     String
@@ -203,28 +203,28 @@ model NomadMix {
   baseAvgRating   Float             @default(4.5)
   createdAt       DateTime          @default(now())
   updatedAt       DateTime          @updatedAt
-  components      NomadMixComponent[]
-  railMixes       NomadRailMix[]
-  ratings         NomadMixRating[]
-  smokeEvents     NomadSmokeCtaEvent[]
+  components      MixComponent[]
+  railMixes       RailMix[]
+  ratings         MixRating[]
+  smokeEvents     SmokeCtaEvent[]
 }
 
-model NomadMixComponent {
+model MixComponent {
   id         String      @id @default(uuid())
   mixId      String
   tobaccoId   String
   proportion  Int         @default(50)
   sortOrder   Int         @default(0)
   createdAt   DateTime    @default(now())
-  mix         NomadMix    @relation(fields: [mixId], references: [id], onDelete: Cascade)
-  tobacco     NomadTobacco @relation(fields: [tobaccoId], references: [id], onDelete: Restrict)
+  mix         Mix    @relation(fields: [mixId], references: [id], onDelete: Cascade)
+  tobacco     Tobacco @relation(fields: [tobaccoId], references: [id], onDelete: Restrict)
 
   @@unique([mixId, tobaccoId])
   @@index([mixId])
   @@index([tobaccoId])
 }
 
-model NomadRail {
+model Rail {
   id          String         @id
   name        String
   description String
@@ -233,42 +233,42 @@ model NomadRail {
   isSystem    Boolean        @default(false)
   createdAt   DateTime       @default(now())
   updatedAt   DateTime       @updatedAt
-  mixes       NomadRailMix[]
+  mixes       RailMix[]
 
   @@index([type])
   @@index([active])
 }
 
-model NomadRailMix {
+model RailMix {
   id         String    @id @default(uuid())
   railId     String
   mixId      String
   sortOrder  Int       @default(0)
   createdAt  DateTime  @default(now())
-  rail       NomadRail @relation(fields: [railId], references: [id], onDelete: Cascade)
-  mix        NomadMix  @relation(fields: [mixId], references: [id], onDelete: Cascade)
+  rail       Rail @relation(fields: [railId], references: [id], onDelete: Cascade)
+  mix        Mix  @relation(fields: [mixId], references: [id], onDelete: Cascade)
 
   @@unique([railId, mixId])
   @@index([railId])
   @@index([mixId])
 }
 
-model NomadSmokeCtaEvent {
+model SmokeCtaEvent {
   id        String    @id @default(uuid())
   mixId     String
   createdAt DateTime  @default(now())
-  mix       NomadMix  @relation(fields: [mixId], references: [id], onDelete: Cascade)
+  mix       Mix  @relation(fields: [mixId], references: [id], onDelete: Cascade)
 
   @@index([mixId])
 }
 
-model NomadMixRating {
+model MixRating {
   id        String    @id @default(uuid())
   mixId     String
   value     Int
   source    String    @default("guest")
   createdAt DateTime  @default(now())
-  mix       NomadMix  @relation(fields: [mixId], references: [id], onDelete: Cascade)
+  mix       Mix  @relation(fields: [mixId], references: [id], onDelete: Cascade)
 
   @@index([mixId])
   @@index([createdAt])

--- a/apps/nomad-backend/prisma/seed.ts
+++ b/apps/nomad-backend/prisma/seed.ts
@@ -57,7 +57,7 @@ const staffAccounts = [
     password: 'nomad',
     passwordSalt: 'seed:staff-nomad',
     name: 'Nomad Staff',
-    role: 'nomad',
+    role: 'master',
     active: true,
   },
 ] as const;
@@ -258,22 +258,22 @@ const railMixes = [
 async function main() {
   const currentCodeWindow = getNomadDailyCodeWindow();
 
-  await prisma.nomadSmokeCtaEvent.deleteMany();
-  await prisma.nomadMixRating.deleteMany();
-  await prisma.nomadRailMix.deleteMany();
-  await prisma.nomadMixComponent.deleteMany();
-  await prisma.nomadRail.deleteMany();
-  await prisma.nomadMix.deleteMany();
-  await prisma.nomadTobacco.deleteMany();
-  await prisma.nomadIntroCard.deleteMany();
-  await prisma.nomadDailyAccessCode.deleteMany();
-  await prisma.nomadTelegramRecipient.deleteMany();
-  await prisma.nomadTelegramOperator.deleteMany();
-  await prisma.nomadTelegramAutomationState.deleteMany();
-  await prisma.nomadAuditEvent.deleteMany();
-  await prisma.nomadStaffAccount.deleteMany();
+  await prisma.smokeCtaEvent.deleteMany();
+  await prisma.mixRating.deleteMany();
+  await prisma.railMix.deleteMany();
+  await prisma.mixComponent.deleteMany();
+  await prisma.rail.deleteMany();
+  await prisma.mix.deleteMany();
+  await prisma.tobacco.deleteMany();
+  await prisma.introCard.deleteMany();
+  await prisma.dailyAccessCode.deleteMany();
+  await prisma.telegramRecipient.deleteMany();
+  await prisma.telegramOperator.deleteMany();
+  await prisma.telegramAutomationState.deleteMany();
+  await prisma.auditEvent.deleteMany();
+  await prisma.staffAccount.deleteMany();
 
-  await prisma.nomadStaffAccount.createMany({
+  await prisma.staffAccount.createMany({
     data: staffAccounts.map((account) => ({
       id: account.id,
       login: account.login,
@@ -286,7 +286,7 @@ async function main() {
     skipDuplicates: true,
   });
 
-  await prisma.nomadDailyAccessCode.createMany({
+  await prisma.dailyAccessCode.createMany({
     data: dailyAccessCodes.map((code) => ({
       id: code.id,
       codeValue: code.code,
@@ -300,11 +300,11 @@ async function main() {
     skipDuplicates: true,
   });
 
-  await prisma.nomadTelegramRecipient.createMany({
+  await prisma.telegramRecipient.createMany({
     data: telegramRecipients,
   });
 
-  await prisma.nomadTelegramOperator.createMany({
+  await prisma.telegramOperator.createMany({
     data: [
       {
         id: 'telegram-operator-anna',
@@ -334,7 +334,7 @@ async function main() {
     skipDuplicates: true,
   });
 
-  await prisma.nomadIntroCard.createMany({
+  await prisma.introCard.createMany({
     data: introCards.map((card) => ({
       id: card.id,
       step: card.step,
@@ -345,7 +345,7 @@ async function main() {
     skipDuplicates: true,
   });
 
-  await prisma.nomadTobacco.createMany({
+  await prisma.tobacco.createMany({
     data: tobaccos.map((tobacco) => ({
       id: tobacco.id,
       manufacturer: tobacco.manufacturer,
@@ -359,7 +359,7 @@ async function main() {
     skipDuplicates: true,
   });
 
-  await prisma.nomadMix.createMany({
+  await prisma.mix.createMany({
     data: mixes.map((mix) => ({
       id: mix.id,
       name: mix.name,
@@ -374,7 +374,7 @@ async function main() {
     skipDuplicates: true,
   });
 
-  await prisma.nomadMixComponent.createMany({
+  await prisma.mixComponent.createMany({
     data: mixComponents.map((component) => ({
       mixId: component.mixId,
       tobaccoId: component.tobaccoId,
@@ -384,7 +384,7 @@ async function main() {
     skipDuplicates: true,
   });
 
-  await prisma.nomadRail.createMany({
+  await prisma.rail.createMany({
     data: rails.map((rail) => ({
       id: rail.id,
       name: rail.name,
@@ -396,7 +396,7 @@ async function main() {
     skipDuplicates: true,
   });
 
-  await prisma.nomadRailMix.createMany({
+  await prisma.railMix.createMany({
     data: railMixes.map((railMix) => ({
       railId: railMix.railId,
       mixId: railMix.mixId,

--- a/apps/nomad-backend/scripts/backfill-flavors.ts
+++ b/apps/nomad-backend/scripts/backfill-flavors.ts
@@ -39,7 +39,7 @@ const main = async () => {
   // таксономия (fallback по profile-only тегам) даёт вкусы из уже сохранённого
   // rawSourceTags. Непустой flavors не трогаем — это защита от затирания ручной
   // курации. flavorProfiles/flavorTags тоже не трогаем: их логика не менялась.
-  const rows = await prisma.nomadTobacco.findMany({
+  const rows = await prisma.tobacco.findMany({
     select: { id: true, name: true, manufacturer: true, rawSourceTags: true, flavors: true },
   });
 
@@ -85,7 +85,7 @@ const main = async () => {
 
   let applied = 0;
   for (const item of updates) {
-    await prisma.nomadTobacco.update({
+    await prisma.tobacco.update({
       where: { id: item.id },
       data: { flavors: serializeList(item.flavors) },
     });

--- a/apps/nomad-backend/scripts/backfill-htreviews-details.ts
+++ b/apps/nomad-backend/scripts/backfill-htreviews-details.ts
@@ -30,7 +30,7 @@ const parseList = (value: string | null | undefined) => {
 const serializeList = (items: string[]) => JSON.stringify(Array.from(new Set(items)));
 
 const updateMixTaxonomy = async () => {
-  const mixes = await prisma.nomadMix.findMany({
+  const mixes = await prisma.mix.findMany({
     include: {
       components: {
         include: {
@@ -51,7 +51,7 @@ const updateMixTaxonomy = async () => {
     const flavors = Array.from(new Set(mix.components.flatMap((item) => parseList(item.tobacco.flavors)))).sort();
     const flavorTags = Array.from(new Set(mix.components.flatMap((item) => parseList(item.tobacco.flavorTags)))).sort();
 
-    await prisma.nomadMix.update({
+    await prisma.mix.update({
       where: {
         id: mix.id,
       },
@@ -74,7 +74,7 @@ async function main() {
   const onlyMissingDescription = process.env.HTREVIEWS_ONLY_MISSING_DESCRIPTION === '1';
   const onlyIncomplete = process.env.HTREVIEWS_ONLY_INCOMPLETE === '1';
 
-  const sourceRows = await prisma.nomadTobacco.findMany({
+  const sourceRows = await prisma.tobacco.findMany({
     where: {
       sourceKind: 'htreviews',
       sourceUrl: {
@@ -130,7 +130,7 @@ async function main() {
         const detail = parseTobaccoPage(html, client.baseUrl, current.sourceUrl!);
         const taxonomy = buildNomadTaxonomyCandidate(detail.rawTags);
 
-        await prisma.nomadTobacco.update({
+        await prisma.tobacco.update({
           where: {
             id: current.id,
           },

--- a/apps/nomad-backend/scripts/bootstrap-admin.ts
+++ b/apps/nomad-backend/scripts/bootstrap-admin.ts
@@ -19,7 +19,7 @@ const main = async () => {
     throw new Error('NOMAD_BOOTSTRAP_ADMIN_PASSWORD is required');
   }
 
-  const current = await prisma.nomadStaffAccount.findUnique({
+  const current = await prisma.staffAccount.findUnique({
     where: { login },
     select: {
       id: true,
@@ -31,7 +31,7 @@ const main = async () => {
   const passwordSalt = `bootstrap:${accountId}:${Date.now()}`;
   const passwordHash = createSecretHash(password, passwordSalt);
 
-  const saved = await prisma.nomadStaffAccount.upsert({
+  const saved = await prisma.staffAccount.upsert({
     where: { login },
     update: {
       name,

--- a/apps/nomad-backend/scripts/build-catalog-backup.ts
+++ b/apps/nomad-backend/scripts/build-catalog-backup.ts
@@ -11,7 +11,7 @@ const prisma = new PrismaClient();
 // Назначение: собрать КАНОНИЧЕСКОЕ состояние данных Nomad поверх уже залитого
 // каталога табаков (htreviews) — 20 миксов из docs/data/top-20-mixes.md и
 // 5 prepared-рейлов из docs/data/preset-rails.md (+ 2 системных statistical).
-// Компоненты миксов матчатся на реальные NomadTobacco по «бренд + вкус».
+// Компоненты миксов матчатся на реальные Tobacco по «бренд + вкус».
 // Если хоть один компонент не сопоставлен — микс пропускается (чистые данные
 // важнее полноты 20/20). Скрипт идемпотентный: владеет слоем mix/rail целиком
 // и пересобирает его при каждом запуске. Состав/тексты табаков не меняет, но
@@ -26,7 +26,7 @@ const maskDatabaseUrl = (url: string | undefined) =>
 
 const DOCS_DIR = path.join(__dirname, '../../../docs/data');
 
-// --- Нормализация брендов: написание в docs → manufacturer в NomadTobacco -----
+// --- Нормализация брендов: написание в docs → manufacturer в Tobacco -----
 const BRAND_MANUFACTURER: Record<string, string> = {
   darkside: 'DARKSIDE',
   'dark side': 'DARKSIDE',
@@ -211,7 +211,7 @@ const parseRails = (): ParsedRail[] => {
   return rails;
 };
 
-// --- Матчинг компонента на NomadTobacco --------------------------------------
+// --- Матчинг компонента на Tobacco --------------------------------------
 type Candidate = { id: string; name: string; inStock: boolean };
 
 const scoreCandidate = (flavorNorm: string, flavorDespaced: string, name: string) => {
@@ -271,7 +271,7 @@ const matchComponent = (
 const main = async () => {
   console.log(`[build-catalog-backup] target DB: ${maskDatabaseUrl(process.env.DATABASE_URL)}`);
 
-  const tobaccoCount = await prisma.nomadTobacco.count();
+  const tobaccoCount = await prisma.tobacco.count();
   console.log(`[build-catalog-backup] табаков в каталоге: ${tobaccoCount}`);
   if (tobaccoCount < 1000) {
     throw new Error(
@@ -282,7 +282,7 @@ const main = async () => {
 
   // Загружаем кандидатов только нужных брендов в память
   const manufacturers = [...new Set(Object.values(BRAND_MANUFACTURER))];
-  const tobaccos = await prisma.nomadTobacco.findMany({
+  const tobaccos = await prisma.tobacco.findMany({
     where: { manufacturer: { in: manufacturers } },
     select: { id: true, name: true, manufacturer: true, inStock: true },
   });
@@ -364,15 +364,15 @@ const main = async () => {
   const builtMixNums = new Set(builtMixes.map((m) => m.num));
   await prisma.$transaction(async (tx) => {
     // Слой mix/rail принадлежит этому скрипту целиком — сносим и пересобираем.
-    await tx.nomadRailMix.deleteMany();
-    await tx.nomadMixComponent.deleteMany();
-    await tx.nomadSmokeCtaEvent.deleteMany();
-    await tx.nomadMixRating.deleteMany();
-    await tx.nomadRail.deleteMany();
-    await tx.nomadMix.deleteMany();
+    await tx.railMix.deleteMany();
+    await tx.mixComponent.deleteMany();
+    await tx.smokeCtaEvent.deleteMany();
+    await tx.mixRating.deleteMany();
+    await tx.rail.deleteMany();
+    await tx.mix.deleteMany();
 
     for (const m of builtMixes) {
-      await tx.nomadMix.create({
+      await tx.mix.create({
         data: {
           id: m.id,
           name: m.mix.name,
@@ -394,7 +394,7 @@ const main = async () => {
     // prepared-рейлы из docs (включаем только успешно созданные миксы)
     for (const rail of parsedRails) {
       const mixNums = rail.mixNums.filter((n) => builtMixNums.has(n));
-      await tx.nomadRail.create({
+      await tx.rail.create({
         data: {
           id: `rail-prepared-${rail.slug}`,
           name: rail.title,
@@ -417,23 +417,23 @@ const main = async () => {
     }
 
     // 2 системных statistical-рейла («Топ по Покурить», «Топ по оценкам») НЕ
-    // храним строками NomadRail: backend синтезирует их на лету из событий
+    // храним строками Rail: backend синтезирует их на лету из событий
     // (buildStatisticalRails в src/state.ts) и не читает statistical-строки.
     // Хранить их = пустые дубли в «Мастер → Менеджер рейлов».
 
     // Весь каталог — «в наличии», чтобы собранные миксы были guest-visible и
     // prepared-рейлы показывались на Главной (инвариант №3: видимость зависит
     // от инвентаря). guestVisible = mix.available && все компоненты inStock.
-    const stocked = await tx.nomadTobacco.updateMany({ data: { inStock: true } });
+    const stocked = await tx.tobacco.updateMany({ data: { inStock: true } });
     console.log(`[build-catalog-backup] помечено «в наличии» табаков: ${stocked.count}`);
   });
 
   const after = {
-    'табаки в наличии': await prisma.nomadTobacco.count({ where: { inStock: true } }),
-    миксы: await prisma.nomadMix.count(),
-    'состав миксов': await prisma.nomadMixComponent.count(),
-    рейлы: await prisma.nomadRail.count(),
-    'связи рейл↔микс': await prisma.nomadRailMix.count(),
+    'табаки в наличии': await prisma.tobacco.count({ where: { inStock: true } }),
+    миксы: await prisma.mix.count(),
+    'состав миксов': await prisma.mixComponent.count(),
+    рейлы: await prisma.rail.count(),
+    'связи рейл↔микс': await prisma.railMix.count(),
   };
   console.log('\n[build-catalog-backup] состояние после записи:');
   console.table(after);

--- a/apps/nomad-backend/scripts/clean-db.ts
+++ b/apps/nomad-backend/scripts/clean-db.ts
@@ -19,31 +19,31 @@ const maskDatabaseUrl = (url: string | undefined) =>
 // дети, потом родители. Операционные данные (staff, daily-коды, intro-карточки,
 // telegram-операторы, аудит) НЕ трогаем — иначе будет нечем логиниться и тестировать.
 const targets = [
-  { label: 'smoke-события', run: () => prisma.nomadSmokeCtaEvent.deleteMany() },
-  { label: 'рейтинги миксов', run: () => prisma.nomadMixRating.deleteMany() },
-  { label: 'связи рейл↔микс', run: () => prisma.nomadRailMix.deleteMany() },
-  { label: 'состав миксов', run: () => prisma.nomadMixComponent.deleteMany() },
-  { label: 'рейлы', run: () => prisma.nomadRail.deleteMany() },
-  { label: 'миксы', run: () => prisma.nomadMix.deleteMany() },
-  { label: 'табаки', run: () => prisma.nomadTobacco.deleteMany() },
-  { label: 'каталог профилей вкуса', run: () => prisma.nomadFlavorProfileCatalog.deleteMany() },
-  { label: 'каталог вкусов', run: () => prisma.nomadFlavorCatalog.deleteMany() },
-  { label: 'каталог мета-тегов', run: () => prisma.nomadFlavorTagCatalog.deleteMany() },
-  { label: 'source-tag маппинги', run: () => prisma.nomadSourceTagMapping.deleteMany() },
+  { label: 'smoke-события', run: () => prisma.smokeCtaEvent.deleteMany() },
+  { label: 'рейтинги миксов', run: () => prisma.mixRating.deleteMany() },
+  { label: 'связи рейл↔микс', run: () => prisma.railMix.deleteMany() },
+  { label: 'состав миксов', run: () => prisma.mixComponent.deleteMany() },
+  { label: 'рейлы', run: () => prisma.rail.deleteMany() },
+  { label: 'миксы', run: () => prisma.mix.deleteMany() },
+  { label: 'табаки', run: () => prisma.tobacco.deleteMany() },
+  { label: 'каталог профилей вкуса', run: () => prisma.flavorProfileCatalog.deleteMany() },
+  { label: 'каталог вкусов', run: () => prisma.flavorCatalog.deleteMany() },
+  { label: 'каталог мета-тегов', run: () => prisma.flavorTagCatalog.deleteMany() },
+  { label: 'source-tag маппинги', run: () => prisma.sourceTagMapping.deleteMany() },
 ] as const;
 
 const counts = async () => ({
-  'smoke-события': await prisma.nomadSmokeCtaEvent.count(),
-  'рейтинги миксов': await prisma.nomadMixRating.count(),
-  'связи рейл↔микс': await prisma.nomadRailMix.count(),
-  'состав миксов': await prisma.nomadMixComponent.count(),
-  рейлы: await prisma.nomadRail.count(),
-  миксы: await prisma.nomadMix.count(),
-  табаки: await prisma.nomadTobacco.count(),
-  'каталог профилей вкуса': await prisma.nomadFlavorProfileCatalog.count(),
-  'каталог вкусов': await prisma.nomadFlavorCatalog.count(),
-  'каталог мета-тегов': await prisma.nomadFlavorTagCatalog.count(),
-  'source-tag маппинги': await prisma.nomadSourceTagMapping.count(),
+  'smoke-события': await prisma.smokeCtaEvent.count(),
+  'рейтинги миксов': await prisma.mixRating.count(),
+  'связи рейл↔микс': await prisma.railMix.count(),
+  'состав миксов': await prisma.mixComponent.count(),
+  рейлы: await prisma.rail.count(),
+  миксы: await prisma.mix.count(),
+  табаки: await prisma.tobacco.count(),
+  'каталог профилей вкуса': await prisma.flavorProfileCatalog.count(),
+  'каталог вкусов': await prisma.flavorCatalog.count(),
+  'каталог мета-тегов': await prisma.flavorTagCatalog.count(),
+  'source-tag маппинги': await prisma.sourceTagMapping.count(),
 });
 
 const main = async () => {
@@ -54,12 +54,12 @@ const main = async () => {
   console.table(before);
 
   const sohranyaem = {
-    'staff-аккаунты': await prisma.nomadStaffAccount.count(),
-    'daily-коды': await prisma.nomadDailyAccessCode.count(),
-    'intro-карточки': await prisma.nomadIntroCard.count(),
-    'telegram-операторы': await prisma.nomadTelegramOperator.count(),
-    'telegram-recipients': await prisma.nomadTelegramRecipient.count(),
-    'аудит-события': await prisma.nomadAuditEvent.count(),
+    'staff-аккаунты': await prisma.staffAccount.count(),
+    'daily-коды': await prisma.dailyAccessCode.count(),
+    'intro-карточки': await prisma.introCard.count(),
+    'telegram-операторы': await prisma.telegramOperator.count(),
+    'telegram-recipients': await prisma.telegramRecipient.count(),
+    'аудит-события': await prisma.auditEvent.count(),
   };
   console.log('[clean-db] сохраняется без изменений:');
   console.table(sohranyaem);

--- a/apps/nomad-backend/src/access.test.ts
+++ b/apps/nomad-backend/src/access.test.ts
@@ -166,7 +166,7 @@ test('staff accounts CRUD is admin-only', async () => {
       payload: {
         login: 'bartender',
         name: 'Bartender',
-        role: 'nomad',
+        role: 'master',
         password: 'bartender',
         active: true,
       },
@@ -177,7 +177,7 @@ test('staff accounts CRUD is admin-only', async () => {
       item: { id: string; login: string; name: string; role: string; active: boolean };
     };
     assert.equal(createdBody.item.login, 'bartender');
-    assert.equal(createdBody.item.role, 'nomad');
+    assert.equal(createdBody.item.role, 'master');
     assert.equal(createdBody.item.active, true);
 
     const updated = await app.inject({

--- a/apps/nomad-backend/src/access.ts
+++ b/apps/nomad-backend/src/access.ts
@@ -160,7 +160,7 @@ const normalizeDateRange = (startsAt?: Date, endsAt?: Date) => {
 };
 
 const normalizeRole = (value: string | undefined): StaffRole | null => {
-  if (value === 'admin' || value === 'nomad') {
+  if (value === 'admin' || value === 'master') {
     return value;
   }
 
@@ -259,7 +259,7 @@ const mapStaffAccount = (record: {
   id: record.id,
   login: record.login,
   name: record.name,
-  role: normalizeRole(record.role) ?? 'nomad',
+  role: normalizeRole(record.role) ?? 'master',
   active: record.active,
   createdAt: record.createdAt.toISOString(),
   updatedAt: record.updatedAt.toISOString(),
@@ -434,7 +434,7 @@ const mapTelegramAutomationState = (
 export const listDailyAccessCodes = async () => {
   await ensureNomadState();
 
-  const records = await prisma.nomadDailyAccessCode.findMany({
+  const records = await prisma.dailyAccessCode.findMany({
     orderBy: [
       { startsAt: 'desc' },
       { createdAt: 'desc' },
@@ -447,7 +447,7 @@ export const listDailyAccessCodes = async () => {
 export const getDailyAccessCodeById = async (id: string) => {
   await ensureNomadState();
 
-  const record = await prisma.nomadDailyAccessCode.findUnique({
+  const record = await prisma.dailyAccessCode.findUnique({
     where: { id },
   });
 
@@ -476,7 +476,7 @@ export const createDailyAccessCode = async (payload: Partial<DailyAccessCodeInpu
 
   const prefix = `daily-code-${slugify(codeLabel)}`;
   const id = await nextPrefixedId(prefix, () =>
-    prisma.nomadDailyAccessCode.count({
+    prisma.dailyAccessCode.count({
       where: {
         id: {
           startsWith: prefix,
@@ -486,7 +486,7 @@ export const createDailyAccessCode = async (payload: Partial<DailyAccessCodeInpu
   );
 
   try {
-    const created = await prisma.nomadDailyAccessCode.create({
+    const created = await prisma.dailyAccessCode.create({
       data: {
         id,
         codeValue,
@@ -512,7 +512,7 @@ export const createDailyAccessCode = async (payload: Partial<DailyAccessCodeInpu
 export const updateDailyAccessCode = async (id: string, payload: DailyAccessCodePatch) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadDailyAccessCode.findUnique({
+  const current = await prisma.dailyAccessCode.findUnique({
     where: { id },
   });
 
@@ -533,7 +533,7 @@ export const updateDailyAccessCode = async (id: string, payload: DailyAccessCode
   }
 
   try {
-    const updated = await prisma.nomadDailyAccessCode.update({
+    const updated = await prisma.dailyAccessCode.update({
       where: { id },
       data: {
         codeValue,
@@ -558,7 +558,7 @@ export const updateDailyAccessCode = async (id: string, payload: DailyAccessCode
 export const deleteDailyAccessCode = async (id: string) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadDailyAccessCode.findUnique({
+  const current = await prisma.dailyAccessCode.findUnique({
     where: { id },
     select: { id: true },
   });
@@ -567,7 +567,7 @@ export const deleteDailyAccessCode = async (id: string) => {
     return false;
   }
 
-  await prisma.nomadDailyAccessCode.delete({
+  await prisma.dailyAccessCode.delete({
     where: { id },
   });
 
@@ -578,7 +578,7 @@ export const getCurrentDailyAccessCode = async () => {
   await ensureNomadState();
 
   const window = getNomadDailyCodeWindow();
-  const records = await prisma.nomadDailyAccessCode.findMany({
+  const records = await prisma.dailyAccessCode.findMany({
     where: dailyCodeWindowFilter(window),
     orderBy: [{ createdAt: 'desc' }, { updatedAt: 'desc' }],
   });
@@ -590,14 +590,14 @@ export const ensureCurrentDailyAccessCode = async () => {
   await ensureNomadState();
 
   const window = getNomadDailyCodeWindow();
-  const records = await prisma.nomadDailyAccessCode.findMany({
+  const records = await prisma.dailyAccessCode.findMany({
     where: dailyCodeWindowFilter(window),
     orderBy: [{ createdAt: 'desc' }, { updatedAt: 'desc' }],
   });
 
   if (records[0]) {
     if (records.length > 1) {
-      await prisma.nomadDailyAccessCode.updateMany({
+      await prisma.dailyAccessCode.updateMany({
         where: {
           id: {
             in: records.slice(1).map((record) => record.id),
@@ -618,7 +618,7 @@ export const ensureCurrentDailyAccessCode = async () => {
 
   const codeValue = createNomadDailyCodeValue(window.startsAt);
   const secret = createAutomationSecret(codeValue);
-  const created = await prisma.nomadDailyAccessCode.create({
+  const created = await prisma.dailyAccessCode.create({
     data: {
       id: `daily-code-${codeValue.toLowerCase()}`,
       codeValue,
@@ -644,13 +644,13 @@ export const rotateCurrentDailyAccessCode = async () => {
   const window = getNomadDailyCodeWindow();
 
   return prisma.$transaction(async (tx) => {
-    const records = await tx.nomadDailyAccessCode.findMany({
+    const records = await tx.dailyAccessCode.findMany({
       where: dailyCodeWindowFilter(window),
       orderBy: [{ createdAt: 'desc' }, { updatedAt: 'desc' }],
     });
 
     if (records.length) {
-      await tx.nomadDailyAccessCode.updateMany({
+      await tx.dailyAccessCode.updateMany({
         where: {
           id: {
             in: records.map((record) => record.id),
@@ -664,7 +664,7 @@ export const rotateCurrentDailyAccessCode = async () => {
 
     const codeValue = createNomadDailyCodeValue(window.startsAt);
     const secret = createAutomationSecret(codeValue);
-    const created = await tx.nomadDailyAccessCode.create({
+    const created = await tx.dailyAccessCode.create({
       data: {
         id: `daily-code-${codeValue.toLowerCase()}`,
         codeValue,
@@ -688,7 +688,7 @@ export const rotateCurrentDailyAccessCode = async () => {
 export const listStaffAccounts = async () => {
   await ensureNomadState();
 
-  const records = await prisma.nomadStaffAccount.findMany({
+  const records = await prisma.staffAccount.findMany({
     orderBy: [
       { active: 'desc' },
       { role: 'asc' },
@@ -702,7 +702,7 @@ export const listStaffAccounts = async () => {
 export const getStaffAccountById = async (id: string) => {
   await ensureNomadState();
 
-  const record = await prisma.nomadStaffAccount.findUnique({
+  const record = await prisma.staffAccount.findUnique({
     where: { id },
   });
 
@@ -724,7 +724,7 @@ export const createStaffAccount = async (payload: Partial<StaffAccountInput>) =>
 
   const prefix = `staff-${slugify(login)}`;
   const id = await nextPrefixedId(prefix, () =>
-    prisma.nomadStaffAccount.count({
+    prisma.staffAccount.count({
       where: {
         id: {
           startsWith: prefix,
@@ -734,7 +734,7 @@ export const createStaffAccount = async (payload: Partial<StaffAccountInput>) =>
   );
 
   try {
-    const created = await prisma.nomadStaffAccount.create({
+    const created = await prisma.staffAccount.create({
       data: {
         id,
         login,
@@ -759,7 +759,7 @@ export const createStaffAccount = async (payload: Partial<StaffAccountInput>) =>
 export const updateStaffAccount = async (id: string, payload: StaffAccountPatch) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadStaffAccount.findUnique({
+  const current = await prisma.staffAccount.findUnique({
     where: { id },
   });
 
@@ -784,7 +784,7 @@ export const updateStaffAccount = async (id: string, payload: StaffAccountPatch)
   const passwordSalt = password ? `seed:${id}:password:${Date.now()}` : current.passwordSalt;
 
   try {
-    const updated = await prisma.nomadStaffAccount.update({
+    const updated = await prisma.staffAccount.update({
       where: { id },
       data: {
         login,
@@ -813,7 +813,7 @@ export const updateStaffAccount = async (id: string, payload: StaffAccountPatch)
 export const deleteStaffAccount = async (id: string) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadStaffAccount.findUnique({
+  const current = await prisma.staffAccount.findUnique({
     where: { id },
     select: { id: true },
   });
@@ -822,7 +822,7 @@ export const deleteStaffAccount = async (id: string) => {
     return false;
   }
 
-  await prisma.nomadStaffAccount.delete({
+  await prisma.staffAccount.delete({
     where: { id },
   });
 
@@ -832,7 +832,7 @@ export const deleteStaffAccount = async (id: string) => {
 export const listTelegramRecipients = async () => {
   await ensureNomadState();
 
-  const records = await prisma.nomadTelegramRecipient.findMany({
+  const records = await prisma.telegramRecipient.findMany({
     orderBy: [{ scope: 'asc' }, { active: 'desc' }, { chatId: 'asc' }],
   });
 
@@ -842,7 +842,7 @@ export const listTelegramRecipients = async () => {
 export const getTelegramRecipientById = async (id: string) => {
   await ensureNomadState();
 
-  const record = await prisma.nomadTelegramRecipient.findUnique({
+  const record = await prisma.telegramRecipient.findUnique({
     where: { id },
   });
 
@@ -852,7 +852,7 @@ export const getTelegramRecipientById = async (id: string) => {
 export const listActiveTelegramRecipients = async () => {
   await ensureNomadState();
 
-  const records = await prisma.nomadTelegramRecipient.findMany({
+  const records = await prisma.telegramRecipient.findMany({
     where: {
       active: true,
     },
@@ -876,7 +876,7 @@ export const createTelegramRecipient = async (payload: Partial<TelegramRecipient
 
   const prefix = `telegram-${scope}-${slugify(chatId)}`;
   const id = await nextPrefixedId(prefix, () =>
-    prisma.nomadTelegramRecipient.count({
+    prisma.telegramRecipient.count({
       where: {
         id: {
           startsWith: prefix,
@@ -886,7 +886,7 @@ export const createTelegramRecipient = async (payload: Partial<TelegramRecipient
   );
 
   try {
-    const created = await prisma.nomadTelegramRecipient.create({
+    const created = await prisma.telegramRecipient.create({
       data: {
         id,
         chatId,
@@ -909,7 +909,7 @@ export const createTelegramRecipient = async (payload: Partial<TelegramRecipient
 export const updateTelegramRecipient = async (id: string, payload: TelegramRecipientPatch) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadTelegramRecipient.findUnique({
+  const current = await prisma.telegramRecipient.findUnique({
     where: { id },
   });
 
@@ -929,7 +929,7 @@ export const updateTelegramRecipient = async (id: string, payload: TelegramRecip
   }
 
   try {
-    const updated = await prisma.nomadTelegramRecipient.update({
+    const updated = await prisma.telegramRecipient.update({
       where: { id },
       data: {
         chatId,
@@ -952,7 +952,7 @@ export const updateTelegramRecipient = async (id: string, payload: TelegramRecip
 export const deleteTelegramRecipient = async (id: string) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadTelegramRecipient.findUnique({
+  const current = await prisma.telegramRecipient.findUnique({
     where: { id },
     select: { id: true },
   });
@@ -961,7 +961,7 @@ export const deleteTelegramRecipient = async (id: string) => {
     return false;
   }
 
-  await prisma.nomadTelegramRecipient.delete({
+  await prisma.telegramRecipient.delete({
     where: { id },
   });
 
@@ -971,7 +971,7 @@ export const deleteTelegramRecipient = async (id: string) => {
 export const listTelegramOperators = async () => {
   await ensureNomadState();
 
-  const records = await prisma.nomadTelegramOperator.findMany({
+  const records = await prisma.telegramOperator.findMany({
     orderBy: [{ active: 'desc' }, { name: 'asc' }, { phone: 'asc' }],
   });
 
@@ -981,7 +981,7 @@ export const listTelegramOperators = async () => {
 export const getTelegramOperatorById = async (id: string) => {
   await ensureNomadState();
 
-  const record = await prisma.nomadTelegramOperator.findUnique({
+  const record = await prisma.telegramOperator.findUnique({
     where: { id },
   });
 
@@ -996,7 +996,7 @@ export const getLinkedTelegramOperatorByChatId = async (chatIdValue: string) => 
     return null;
   }
 
-  const record = await prisma.nomadTelegramOperator.findFirst({
+  const record = await prisma.telegramOperator.findFirst({
     where: {
       linkedChatId: chatId,
       active: true,
@@ -1019,7 +1019,7 @@ export const createTelegramOperator = async (payload: Partial<TelegramOperatorIn
 
   const prefix = `telegram-operator-${slugify(name)}`;
   const id = await nextPrefixedId(prefix, () =>
-    prisma.nomadTelegramOperator.count({
+    prisma.telegramOperator.count({
       where: {
         id: {
           startsWith: prefix,
@@ -1029,7 +1029,7 @@ export const createTelegramOperator = async (payload: Partial<TelegramOperatorIn
   );
 
   try {
-    const created = await prisma.nomadTelegramOperator.create({
+    const created = await prisma.telegramOperator.create({
       data: {
         id,
         name,
@@ -1051,7 +1051,7 @@ export const createTelegramOperator = async (payload: Partial<TelegramOperatorIn
 export const updateTelegramOperator = async (id: string, payload: TelegramOperatorPatch) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadTelegramOperator.findUnique({
+  const current = await prisma.telegramOperator.findUnique({
     where: { id },
   });
 
@@ -1069,7 +1069,7 @@ export const updateTelegramOperator = async (id: string, payload: TelegramOperat
   }
 
   try {
-    const updated = await prisma.nomadTelegramOperator.update({
+    const updated = await prisma.telegramOperator.update({
       where: { id },
       data: {
         name,
@@ -1100,7 +1100,7 @@ export const updateTelegramOperator = async (id: string, payload: TelegramOperat
 export const deleteTelegramOperator = async (id: string) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadTelegramOperator.findUnique({
+  const current = await prisma.telegramOperator.findUnique({
     where: { id },
     select: { id: true },
   });
@@ -1109,7 +1109,7 @@ export const deleteTelegramOperator = async (id: string) => {
     return false;
   }
 
-  await prisma.nomadTelegramOperator.delete({
+  await prisma.telegramOperator.delete({
     where: { id },
   });
 
@@ -1133,7 +1133,7 @@ export const linkTelegramOperator = async (payload: Partial<TelegramOperatorLink
     return { error: 'phone and chatId are required' };
   }
 
-  const operator = await prisma.nomadTelegramOperator.findUnique({
+  const operator = await prisma.telegramOperator.findUnique({
     where: {
       phone,
     },
@@ -1144,7 +1144,7 @@ export const linkTelegramOperator = async (payload: Partial<TelegramOperatorLink
   }
 
   const linked = await prisma.$transaction(async (tx) => {
-    await tx.nomadTelegramOperator.updateMany({
+    await tx.telegramOperator.updateMany({
       where: {
         linkedChatId: chatId,
         NOT: {
@@ -1160,7 +1160,7 @@ export const linkTelegramOperator = async (payload: Partial<TelegramOperatorLink
       },
     });
 
-    return tx.nomadTelegramOperator.update({
+    return tx.telegramOperator.update({
       where: {
         id: operator.id,
       },
@@ -1180,7 +1180,7 @@ export const linkTelegramOperator = async (payload: Partial<TelegramOperatorLink
 export const getTelegramAutomationState = async () => {
   await ensureNomadState();
 
-  const record = await prisma.nomadTelegramAutomationState.findUnique({
+  const record = await prisma.telegramAutomationState.findUnique({
     where: {
       id: TELEGRAM_AUTOMATION_STATE_ID,
     },
@@ -1230,7 +1230,7 @@ export const reportTelegramAutomationState = async (payload: Partial<TelegramAut
       return { error: 'chatId is required for request event' };
     }
 
-    const operator = await prisma.nomadTelegramOperator.findFirst({
+    const operator = await prisma.telegramOperator.findFirst({
       where: {
         linkedChatId: chatId,
         active: true,
@@ -1268,7 +1268,7 @@ export const reportTelegramAutomationState = async (payload: Partial<TelegramAut
 
   const updated = await prisma.$transaction(async (tx) => {
     if (event === 'request' && requestOperator) {
-      await tx.nomadTelegramOperator.update({
+      await tx.telegramOperator.update({
         where: {
           id: requestOperator.id,
         },
@@ -1278,7 +1278,7 @@ export const reportTelegramAutomationState = async (payload: Partial<TelegramAut
       });
     }
 
-    return tx.nomadTelegramAutomationState.upsert({
+    return tx.telegramAutomationState.upsert({
       where: {
         id: TELEGRAM_AUTOMATION_STATE_ID,
       },

--- a/apps/nomad-backend/src/audit.ts
+++ b/apps/nomad-backend/src/audit.ts
@@ -81,7 +81,7 @@ const mapAuditEvent = (record: {
   id: record.id,
   actorLogin: record.actorLogin,
   actorName: record.actorName,
-  actorRole: record.actorRole === 'admin' ? 'admin' : 'nomad',
+  actorRole: record.actorRole === 'admin' ? 'admin' : 'master',
   action: isAuditAction(record.action) ? record.action : 'update',
   entityType: isAuditEntityType(record.entityType) ? record.entityType : 'inventory',
   entityId: record.entityId,
@@ -93,7 +93,7 @@ const mapAuditEvent = (record: {
 export const recordAuditEvent = async (payload: AuditEventInput) => {
   await ensureNomadState();
 
-  const created = await prisma.nomadAuditEvent.create({
+  const created = await prisma.auditEvent.create({
     data: {
       actorLogin: payload.actor.login,
       actorName: payload.actor.name,
@@ -112,7 +112,7 @@ export const recordAuditEvent = async (payload: AuditEventInput) => {
 export const listAuditEvents = async (limit = 40) => {
   await ensureNomadState();
 
-  const records = await prisma.nomadAuditEvent.findMany({
+  const records = await prisma.auditEvent.findMany({
     orderBy: {
       createdAt: 'desc',
     },

--- a/apps/nomad-backend/src/auth.test.ts
+++ b/apps/nomad-backend/src/auth.test.ts
@@ -58,7 +58,7 @@ test('staff login is resolved from persisted staff accounts', async () => {
     };
 
     assert.equal(loginBody.user.login, 'nomad');
-    assert.equal(loginBody.user.role, 'nomad');
+    assert.equal(loginBody.user.role, 'master');
     assert.equal(loginBody.user.name, 'Nomad Staff');
 
     const me = await app.inject({
@@ -72,7 +72,7 @@ test('staff login is resolved from persisted staff accounts', async () => {
     assert.equal(me.statusCode, 200);
     const meBody = me.json() as { user: { login: string; role: string } };
     assert.equal(meBody.user.login, 'nomad');
-    assert.equal(meBody.user.role, 'nomad');
+    assert.equal(meBody.user.role, 'master');
 
     const wrongPassword = await app.inject({
       method: 'POST',

--- a/apps/nomad-backend/src/auth.ts
+++ b/apps/nomad-backend/src/auth.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 import { config } from './config';
 import { prisma } from './db';
 
-export type StaffRole = 'admin' | 'nomad';
+export type StaffRole = 'admin' | 'master';
 
 export type StaffUser = {
   login: string;
@@ -30,7 +30,7 @@ const sign = (value: string) => crypto.createHmac('sha256', config.tokenSecret).
 
 const hashSecret = (secret: string, salt: string) => crypto.scryptSync(secret, salt, 64).toString('hex');
 
-const isStaffRole = (value: string): value is StaffRole => value === 'admin' || value === 'nomad';
+const isStaffRole = (value: string): value is StaffRole => value === 'admin' || value === 'master';
 
 const verifySecret = (secret: string, hash: string, salt: string) => {
   const expected = Buffer.from(hash, 'hex');
@@ -86,7 +86,7 @@ export const verifyStaffToken = (token: string): StaffUser | null => {
 };
 
 export const resolveStaffUser = async (login: string, password: string): Promise<StaffUser | null> => {
-  const account = await prisma.nomadStaffAccount.findUnique({
+  const account = await prisma.staffAccount.findUnique({
     where: { login },
     select: {
       login: true,
@@ -119,7 +119,7 @@ export const resolveStaffSession = async (token: string): Promise<StaffUser | nu
     return null;
   }
 
-  const account = await prisma.nomadStaffAccount.findUnique({
+  const account = await prisma.staffAccount.findUnique({
     where: { login: claims.login },
     select: {
       login: true,
@@ -142,7 +142,7 @@ export const resolveStaffSession = async (token: string): Promise<StaffUser | nu
 
 export const verifyGuestAccessCode = async (code: string) => {
   const now = new Date();
-  const codes = await prisma.nomadDailyAccessCode.findMany({
+  const codes = await prisma.dailyAccessCode.findMany({
     where: {
       active: true,
       startsAt: {

--- a/apps/nomad-backend/src/integrations/htreviews/sync.ts
+++ b/apps/nomad-backend/src/integrations/htreviews/sync.ts
@@ -53,7 +53,7 @@ const buildUpsertData = (item: HtReviewsImportedTobacco, inStock: boolean) => ({
 
 const findExistingRecord = async (item: HtReviewsImportedTobacco) => {
   if (item.sourceExternalId) {
-    const bySourceId = await prisma.nomadTobacco.findUnique({
+    const bySourceId = await prisma.tobacco.findUnique({
       where: {
         sourceExternalId: item.sourceExternalId,
       },
@@ -63,7 +63,7 @@ const findExistingRecord = async (item: HtReviewsImportedTobacco) => {
     }
   }
 
-  const byStableId = await prisma.nomadTobacco.findUnique({
+  const byStableId = await prisma.tobacco.findUnique({
     where: {
       id: toStableId(item),
     },
@@ -72,7 +72,7 @@ const findExistingRecord = async (item: HtReviewsImportedTobacco) => {
     return byStableId;
   }
 
-  const bySourceUrl = await prisma.nomadTobacco.findFirst({
+  const bySourceUrl = await prisma.tobacco.findFirst({
     where: {
       sourceUrl: item.sourceUrl,
     },
@@ -88,7 +88,7 @@ const findExistingRecord = async (item: HtReviewsImportedTobacco) => {
     return null;
   }
 
-  return prisma.nomadTobacco.findFirst({
+  return prisma.tobacco.findFirst({
     where: {
       manufacturer: item.manufacturer,
       lineName: item.lineName ?? '',
@@ -127,7 +127,7 @@ export const syncHtReviewsCatalogToNomad = async (
     const data = buildUpsertData(item, nextInStock);
 
     if (existing) {
-      await prisma.nomadTobacco.update({
+      await prisma.tobacco.update({
         where: {
           id: existing.id,
         },
@@ -135,7 +135,7 @@ export const syncHtReviewsCatalogToNomad = async (
       });
       updated += 1;
     } else {
-      await prisma.nomadTobacco.create({
+      await prisma.tobacco.create({
         data: {
           id: toStableId(item),
           ...data,

--- a/apps/nomad-backend/src/state.ts
+++ b/apps/nomad-backend/src/state.ts
@@ -380,7 +380,7 @@ type SeedStaffAccount = {
   password: string;
   passwordSalt: string;
   name: string;
-  role: 'admin' | 'nomad';
+  role: 'admin' | 'master';
   active: boolean;
 };
 
@@ -461,7 +461,7 @@ const seedStaffAccounts: SeedStaffAccount[] = [
     password: 'nomad',
     passwordSalt: 'seed:staff-nomad',
     name: 'Nomad Staff',
-    role: 'nomad',
+    role: 'master',
     active: true,
   },
 ];
@@ -717,14 +717,14 @@ const mixViewSort = (left: MixView, right: MixView) => {
 };
 
 const syncIntroCards = async () => {
-  const existingCards = await prisma.nomadIntroCard.findMany();
+  const existingCards = await prisma.introCard.findMany();
   const existingById = new Map(existingCards.map((card) => [card.id, card]));
   const expectedIds = new Set(introCards.map((card) => card.id));
 
   await prisma.$transaction(async (tx) => {
     for (const staleCard of existingCards) {
       if (!expectedIds.has(staleCard.id)) {
-        await tx.nomadIntroCard.delete({
+        await tx.introCard.delete({
           where: {
             id: staleCard.id,
           },
@@ -736,7 +736,7 @@ const syncIntroCards = async () => {
       const current = existingById.get(card.id);
 
       if (!current) {
-        await tx.nomadIntroCard.create({
+        await tx.introCard.create({
           data: {
             id: card.id,
             step: card.step,
@@ -756,7 +756,7 @@ const syncIntroCards = async () => {
         current.bullets !== nextBullets;
 
       if (needsUpdate) {
-        await tx.nomadIntroCard.update({
+        await tx.introCard.update({
           where: {
             id: card.id,
           },
@@ -895,7 +895,7 @@ const mapMixView = (record: {
 };
 
 const fetchMixViews = async () => {
-  const records = await prisma.nomadMix.findMany({
+  const records = await prisma.mix.findMany({
     include: {
       components: {
         orderBy: { sortOrder: 'asc' },
@@ -1195,7 +1195,7 @@ const validateMixComponents = async (componentIds: string[]) => {
     return { error: 'At least one component is required', componentIds: [] as string[] };
   }
 
-  const tobaccos = await prisma.nomadTobacco.findMany({
+  const tobaccos = await prisma.tobacco.findMany({
     where: {
       id: {
         in: normalized,
@@ -1360,7 +1360,7 @@ const normalizeRailMixIds = async (mixIds: string[]) => {
     return { error: 'At least one mix is required', mixIds: [] as string[] };
   }
 
-  const mixes = await prisma.nomadMix.findMany({
+  const mixes = await prisma.mix.findMany({
     where: {
       id: {
         in: normalized,
@@ -1403,7 +1403,7 @@ const validateRailInput = async (payload: Partial<RailInput>) => {
 
 const nextMixId = async (name: string) => {
   const prefix = `mix-${slugify(name)}`;
-  const total = await prisma.nomadMix.count({
+  const total = await prisma.mix.count({
     where: {
       id: {
         startsWith: prefix,
@@ -1416,7 +1416,7 @@ const nextMixId = async (name: string) => {
 
 const nextTobaccoId = async (manufacturer: string, lineName: string, name: string) => {
   const prefix = `tobacco-${slugify(`${manufacturer} ${lineName} ${name}`)}`;
-  const total = await prisma.nomadTobacco.count({
+  const total = await prisma.tobacco.count({
     where: {
       id: {
         startsWith: prefix,
@@ -1429,7 +1429,7 @@ const nextTobaccoId = async (manufacturer: string, lineName: string, name: strin
 
 const nextRailId = async (name: string) => {
   const prefix = `rail-${slugify(name)}`;
-  const total = await prisma.nomadRail.count({
+  const total = await prisma.rail.count({
     where: {
       id: {
         startsWith: prefix,
@@ -1443,27 +1443,27 @@ const nextRailId = async (name: string) => {
 type NomadStorageTx = Parameters<Parameters<typeof prisma.$transaction>[0]>[0];
 
 const wipeNomadStorage = async (tx: NomadStorageTx) => {
-  await tx.nomadSmokeCtaEvent.deleteMany();
-  await tx.nomadMixRating.deleteMany();
-  await tx.nomadRailMix.deleteMany();
-  await tx.nomadMixComponent.deleteMany();
-  await tx.nomadRail.deleteMany();
-  await tx.nomadMix.deleteMany();
-  await tx.nomadTobacco.deleteMany();
-  await tx.nomadIntroCard.deleteMany();
-  await tx.nomadDailyAccessCode.deleteMany();
-  await tx.nomadTelegramRecipient.deleteMany();
-  await tx.nomadTelegramOperator.deleteMany();
-  await tx.nomadTelegramAutomationState.deleteMany();
-  await tx.nomadAuditEvent.deleteMany();
-  await tx.nomadStaffAccount.deleteMany();
+  await tx.smokeCtaEvent.deleteMany();
+  await tx.mixRating.deleteMany();
+  await tx.railMix.deleteMany();
+  await tx.mixComponent.deleteMany();
+  await tx.rail.deleteMany();
+  await tx.mix.deleteMany();
+  await tx.tobacco.deleteMany();
+  await tx.introCard.deleteMany();
+  await tx.dailyAccessCode.deleteMany();
+  await tx.telegramRecipient.deleteMany();
+  await tx.telegramOperator.deleteMany();
+  await tx.telegramAutomationState.deleteMany();
+  await tx.auditEvent.deleteMany();
+  await tx.staffAccount.deleteMany();
 };
 
 const insertNomadOperationalState = async (
   tx: NomadStorageTx,
   currentCodeWindow: ReturnType<typeof getNomadDailyCodeWindow>,
 ) => {
-  await tx.nomadStaffAccount.createMany({
+  await tx.staffAccount.createMany({
     data: seedStaffAccounts.map((account) => ({
       id: account.id,
       login: account.login,
@@ -1475,7 +1475,7 @@ const insertNomadOperationalState = async (
     })),
   });
 
-  await tx.nomadDailyAccessCode.createMany({
+  await tx.dailyAccessCode.createMany({
     data: seedDailyAccessCodes.map((code) => ({
       id: code.id,
       codeValue: code.code,
@@ -1488,7 +1488,7 @@ const insertNomadOperationalState = async (
     })),
   });
 
-  await tx.nomadTelegramRecipient.createMany({
+  await tx.telegramRecipient.createMany({
     data: seedTelegramRecipients.map((recipient) => ({
       id: recipient.id,
       chatId: recipient.chatId,
@@ -1498,7 +1498,7 @@ const insertNomadOperationalState = async (
     })),
   });
 
-  await tx.nomadTelegramOperator.createMany({
+  await tx.telegramOperator.createMany({
     data: seedTelegramOperators.map((operator) => ({
       id: operator.id,
       name: operator.name,
@@ -1513,7 +1513,7 @@ const insertNomadOperationalState = async (
     })),
   });
 
-  await tx.nomadIntroCard.createMany({
+  await tx.introCard.createMany({
     data: introCards.map((card) => ({
       id: card.id,
       step: card.step,
@@ -1525,7 +1525,7 @@ const insertNomadOperationalState = async (
 };
 
 const insertNomadSeedCatalog = async (tx: NomadStorageTx) => {
-  await tx.nomadTobacco.createMany({
+  await tx.tobacco.createMany({
     data: seedTobaccos.map((tobacco) => ({
       id: tobacco.id,
       manufacturer: tobacco.manufacturer,
@@ -1538,7 +1538,7 @@ const insertNomadSeedCatalog = async (tx: NomadStorageTx) => {
     })),
   });
 
-  await tx.nomadMix.createMany({
+  await tx.mix.createMany({
     data: seedMixes.map((mix) => {
       const components = mix.componentIds
         .map((componentId) => seedTobaccos.find((item) => item.id === componentId))
@@ -1558,7 +1558,7 @@ const insertNomadSeedCatalog = async (tx: NomadStorageTx) => {
     }),
   });
 
-  await tx.nomadMixComponent.createMany({
+  await tx.mixComponent.createMany({
     data: seedMixes.flatMap((mix) =>
       distributeMixComponentProportions(mix.componentIds).map((component) => ({
         mixId: mix.id,
@@ -1569,7 +1569,7 @@ const insertNomadSeedCatalog = async (tx: NomadStorageTx) => {
     ),
   });
 
-  await tx.nomadRail.createMany({
+  await tx.rail.createMany({
     data: defaultRails.map((rail) => ({
       id: rail.id,
       name: rail.name,
@@ -1580,7 +1580,7 @@ const insertNomadSeedCatalog = async (tx: NomadStorageTx) => {
     })),
   });
 
-  await tx.nomadRailMix.createMany({
+  await tx.railMix.createMany({
     data: defaultRails.flatMap((rail) =>
       rail.mixIds.map((mixId, index) => ({
         railId: rail.id,
@@ -1618,7 +1618,7 @@ export const ensureNomadState = async () => {
   }
 
   bootstrapPromise = (async () => {
-    const staffAccountCount = await prisma.nomadStaffAccount.count();
+    const staffAccountCount = await prisma.staffAccount.count();
     if (!staffAccountCount) {
       await bootstrapNomadOperationalState();
     }
@@ -1643,7 +1643,7 @@ export const getGuestIntroCards = async () => {
   await ensureNomadState();
   await syncIntroCards();
 
-  const records = await prisma.nomadIntroCard.findMany({
+  const records = await prisma.introCard.findMany({
     orderBy: {
       step: 'asc',
     },
@@ -1656,7 +1656,7 @@ export const getInventoryTobaccos = async (query: InventoryListQuery = {}): Prom
   await ensureNomadState();
 
   const [records, mixes] = await Promise.all([
-    prisma.nomadTobacco.findMany(),
+    prisma.tobacco.findMany(),
     fetchMixViews(),
   ]);
 
@@ -1795,7 +1795,7 @@ export const getInventoryTobaccos = async (query: InventoryListQuery = {}): Prom
 export const getTobaccoById = async (id: string) => {
   await ensureNomadState();
 
-  const tobacco = await prisma.nomadTobacco.findUnique({
+  const tobacco = await prisma.tobacco.findUnique({
     where: { id },
   });
 
@@ -1813,7 +1813,7 @@ export const createTobacco = async (payload: Partial<TobaccoInput>) => {
     return { error: 'Manufacturer and name are required' };
   }
 
-  const existing = await prisma.nomadTobacco.findFirst({
+  const existing = await prisma.tobacco.findFirst({
     where: {
       manufacturer,
       lineName,
@@ -1830,7 +1830,7 @@ export const createTobacco = async (payload: Partial<TobaccoInput>) => {
 
   const id = await nextTobaccoId(manufacturer, lineName, name);
 
-  await prisma.nomadTobacco.create({
+  await prisma.tobacco.create({
     data: {
       id,
       manufacturer,
@@ -1857,7 +1857,7 @@ export const createTobacco = async (payload: Partial<TobaccoInput>) => {
 export const updateTobacco = async (id: string, payload: TobaccoPatch) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadTobacco.findUnique({
+  const current = await prisma.tobacco.findUnique({
     where: { id },
   });
 
@@ -1881,7 +1881,7 @@ export const updateTobacco = async (id: string, payload: TobaccoPatch) => {
       ? payload.inStock
       : current.inStock;
 
-  const duplicate = await prisma.nomadTobacco.findFirst({
+  const duplicate = await prisma.tobacco.findFirst({
     where: {
       manufacturer,
       lineName,
@@ -1899,7 +1899,7 @@ export const updateTobacco = async (id: string, payload: TobaccoPatch) => {
     return { error: 'Такой табак уже существует в каталоге' };
   }
 
-  await prisma.nomadTobacco.update({
+  await prisma.tobacco.update({
     where: { id },
     data: {
       manufacturer,
@@ -1938,7 +1938,7 @@ export const updateTobacco = async (id: string, payload: TobaccoPatch) => {
 export const updateTobaccoInStock = async (id: string, inStock: boolean) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadTobacco.findUnique({
+  const current = await prisma.tobacco.findUnique({
     where: { id },
   });
 
@@ -1946,7 +1946,7 @@ export const updateTobaccoInStock = async (id: string, inStock: boolean) => {
     return null;
   }
 
-  await prisma.nomadTobacco.update({
+  await prisma.tobacco.update({
     where: { id },
     data: { inStock },
   });
@@ -1980,7 +1980,7 @@ export const batchUpdateTobacco = async (
         : action === 'archive'
           ? { archived: true, inStock: false }
           : { archived: false };
-  const currentItems = await prisma.nomadTobacco.findMany({
+  const currentItems = await prisma.tobacco.findMany({
     where: {
       id: {
         in: normalizedIds,
@@ -1990,7 +1990,7 @@ export const batchUpdateTobacco = async (
   const currentIds = currentItems.map((item) => item.id);
   const skippedIds = normalizedIds.filter((id) => !currentIds.includes(id));
 
-  await prisma.nomadTobacco.updateMany({
+  await prisma.tobacco.updateMany({
     where: {
       id: {
         in: currentIds,
@@ -2057,7 +2057,7 @@ export const getGuestCatalogMixes = async (filters?: { profiles?: string[]; flav
 const buildMostSelectedRail = async (): Promise<RailView> => {
   const [mixes, events] = await Promise.all([
     getAvailableMixCatalog(),
-    prisma.nomadSmokeCtaEvent.findMany({
+    prisma.smokeCtaEvent.findMany({
       select: {
         mixId: true,
       },
@@ -2154,7 +2154,7 @@ const buildRailViews = async (guestOnly: boolean) => {
 
   const [mixes, rails] = await Promise.all([
     getAvailableMixCatalog(),
-    prisma.nomadRail.findMany({
+    prisma.rail.findMany({
       where: guestOnly
         ? {
             active: true,
@@ -2307,7 +2307,7 @@ export const createMix = async (payload: Partial<MixInput>) => {
   const id = await nextMixId(validated.name);
 
   await prisma.$transaction(async (tx) => {
-    await tx.nomadMix.create({
+    await tx.mix.create({
       data: {
         id,
         name: validated.name,
@@ -2321,7 +2321,7 @@ export const createMix = async (payload: Partial<MixInput>) => {
       },
     });
 
-    await tx.nomadMixComponent.createMany({
+    await tx.mixComponent.createMany({
       data: validated.components.map((component) => ({
         mixId: id,
         tobaccoId: component.tobaccoId,
@@ -2337,7 +2337,7 @@ export const createMix = async (payload: Partial<MixInput>) => {
 export const updateMix = async (id: string, payload: MixPatch) => {
   await ensureNomadState();
 
-  const current = await prisma.nomadMix.findUnique({
+  const current = await prisma.mix.findUnique({
     where: { id },
     include: {
       components: {
@@ -2373,7 +2373,7 @@ export const updateMix = async (id: string, payload: MixPatch) => {
   }
 
   await prisma.$transaction(async (tx) => {
-    await tx.nomadMix.update({
+    await tx.mix.update({
       where: { id },
       data: {
         name: nextName,
@@ -2388,11 +2388,11 @@ export const updateMix = async (id: string, payload: MixPatch) => {
     });
 
     if (Array.isArray(payload.components) || Array.isArray(payload.componentIds)) {
-      await tx.nomadMixComponent.deleteMany({
+      await tx.mixComponent.deleteMany({
         where: { mixId: id },
       });
 
-      await tx.nomadMixComponent.createMany({
+      await tx.mixComponent.createMany({
         data: componentValidation.components.map((component) => ({
           mixId: id,
           tobaccoId: component.tobaccoId,
@@ -2412,12 +2412,12 @@ export const updateMix = async (id: string, payload: MixPatch) => {
 export const deleteMix = async (id: string): Promise<{ id: string; name: string } | null> => {
   await ensureNomadState();
 
-  const current = await prisma.nomadMix.findUnique({ where: { id } });
+  const current = await prisma.mix.findUnique({ where: { id } });
   if (!current) {
     return null;
   }
 
-  await prisma.nomadMix.delete({ where: { id } });
+  await prisma.mix.delete({ where: { id } });
 
   return { id: current.id, name: current.name };
 };
@@ -2429,12 +2429,12 @@ export const deleteRail = async (id: string) => {
     return { error: statisticalRailReadOnlyReason };
   }
 
-  const current = await prisma.nomadRail.findUnique({ where: { id } });
+  const current = await prisma.rail.findUnique({ where: { id } });
   if (!current) {
     return null;
   }
 
-  await prisma.nomadRail.delete({ where: { id } });
+  await prisma.rail.delete({ where: { id } });
 
   return { id: current.id, name: current.name };
 };
@@ -2454,7 +2454,7 @@ export const createRail = async (payload: Partial<RailInput>) => {
   const id = await nextRailId(validated.name);
 
   await prisma.$transaction(async (tx) => {
-    await tx.nomadRail.create({
+    await tx.rail.create({
       data: {
         id,
         name: validated.name,
@@ -2465,7 +2465,7 @@ export const createRail = async (payload: Partial<RailInput>) => {
       },
     });
 
-    await tx.nomadRailMix.createMany({
+    await tx.railMix.createMany({
       data: validated.mixIds.map((mixId, index) => ({
         railId: id,
         mixId,
@@ -2484,7 +2484,7 @@ export const updateRail = async (id: string, payload: RailPatch) => {
     return { error: statisticalRailReadOnlyReason };
   }
 
-  const current = await prisma.nomadRail.findUnique({
+  const current = await prisma.rail.findUnique({
     where: { id },
     include: {
       mixes: {
@@ -2518,7 +2518,7 @@ export const updateRail = async (id: string, payload: RailPatch) => {
   }
 
   await prisma.$transaction(async (tx) => {
-    await tx.nomadRail.update({
+    await tx.rail.update({
       where: { id },
       data: {
         name: nextName,
@@ -2529,11 +2529,11 @@ export const updateRail = async (id: string, payload: RailPatch) => {
     });
 
     if (Array.isArray(payload.mixIds)) {
-      await tx.nomadRailMix.deleteMany({
+      await tx.railMix.deleteMany({
         where: { railId: id },
       });
 
-      await tx.nomadRailMix.createMany({
+      await tx.railMix.createMany({
         data: railMixIds.mixIds.map((mixId, index) => ({
           railId: id,
           mixId,
@@ -2549,7 +2549,7 @@ export const updateRail = async (id: string, payload: RailPatch) => {
 export const recordSmokeCtaEvent = async (mixId: string) => {
   await ensureNomadState();
 
-  const event = await prisma.nomadSmokeCtaEvent.create({
+  const event = await prisma.smokeCtaEvent.create({
     data: { mixId },
   });
 
@@ -2562,7 +2562,7 @@ export const recordSmokeCtaEvent = async (mixId: string) => {
 export const getSmokeCtaEvents = async () => {
   await ensureNomadState();
 
-  const events = await prisma.nomadSmokeCtaEvent.findMany({
+  const events = await prisma.smokeCtaEvent.findMany({
     orderBy: {
       createdAt: 'asc',
     },
@@ -2577,7 +2577,7 @@ export const getSmokeCtaEvents = async () => {
 export const rateMix = async (id: string, value: number) => {
   await ensureNomadState();
 
-  const mix = await prisma.nomadMix.findUnique({
+  const mix = await prisma.mix.findUnique({
     where: { id },
     select: { id: true },
   });
@@ -2590,7 +2590,7 @@ export const rateMix = async (id: string, value: number) => {
     return { error: 'Rating value must be between 1 and 5' };
   }
 
-  await prisma.nomadMixRating.create({
+  await prisma.mixRating.create({
     data: {
       mixId: id,
       value,
@@ -2605,8 +2605,8 @@ export const getInventorySummary = async () => {
   await ensureNomadState();
 
   const [total, inStockCount] = await Promise.all([
-    prisma.nomadTobacco.count(),
-    prisma.nomadTobacco.count({
+    prisma.tobacco.count(),
+    prisma.tobacco.count({
       where: {
         inStock: true,
       },
@@ -2625,7 +2625,7 @@ export const getSmokeCtaSummary = async () => {
 
   const [mixes, events] = await Promise.all([
     getAvailableMixCatalog(),
-    prisma.nomadSmokeCtaEvent.findMany({
+    prisma.smokeCtaEvent.findMany({
       select: {
         mixId: true,
       },
@@ -2668,7 +2668,7 @@ export const getDashboardSummary = async (windowKey: DashboardWindowKey = '14d')
 
   const window = buildDashboardWindow(windowKey);
   const [inventoryRecords, mixes, rails, smokeEvents, ratingEvents, blockedMixRecords] = await Promise.all([
-    prisma.nomadTobacco.findMany({
+    prisma.tobacco.findMany({
       orderBy: [{ manufacturer: 'asc' }, { name: 'asc' }],
       select: {
         id: true,
@@ -2681,7 +2681,7 @@ export const getDashboardSummary = async (windowKey: DashboardWindowKey = '14d')
     }),
     getAvailableMixCatalog(),
     getStaffRails(),
-    prisma.nomadSmokeCtaEvent.findMany({
+    prisma.smokeCtaEvent.findMany({
       where: {
         createdAt: {
           gte: window.startsAtDate,
@@ -2693,7 +2693,7 @@ export const getDashboardSummary = async (windowKey: DashboardWindowKey = '14d')
         createdAt: true,
       },
     }),
-    prisma.nomadMixRating.findMany({
+    prisma.mixRating.findMany({
       where: {
         createdAt: {
           gte: window.startsAtDate,
@@ -2706,7 +2706,7 @@ export const getDashboardSummary = async (windowKey: DashboardWindowKey = '14d')
         createdAt: true,
       },
     }),
-    prisma.nomadMix.findMany({
+    prisma.mix.findMany({
       where: {
         available: true,
       },

--- a/apps/nomad-backend/src/types.ts
+++ b/apps/nomad-backend/src/types.ts
@@ -86,7 +86,7 @@ export type StaffAuthResponse = {
   user: {
     login: string;
     name: string;
-    role: 'admin' | 'nomad';
+    role: 'admin' | 'master';
   };
 };
 

--- a/apps/nomad-master-web/src/App.tsx
+++ b/apps/nomad-master-web/src/App.tsx
@@ -126,7 +126,7 @@ const resolveRailMixSummary = (rail: RailRecord, mixes: MixRecord[]) => {
   return resolvedNames.join(', ') || 'Миксы не заданы';
 };
 
-const formatRoleLabel = (role: StaffUser['role']) => (role === 'admin' ? 'admin' : 'nomad');
+const formatRoleLabel = (role: StaffUser['role']) => (role === 'admin' ? 'admin' : 'master');
 
 export const App = () => {
   const [login, setLogin] = useState('admin');

--- a/apps/nomad-master-web/src/components/access/staff-block.tsx
+++ b/apps/nomad-master-web/src/components/access/staff-block.tsx
@@ -284,7 +284,7 @@ export const StaffBlock = ({
                 <div className="operator-dialog__field">
                   <label className="operator-dialog__label">Роль</label>
                   <div className="operator-dialog__role-switch" role="radiogroup" aria-label="Роль">
-                    {(['admin', 'nomad'] as const).map((roleKey) => {
+                    {(['admin', 'master'] as const).map((roleKey) => {
                       const active = staffAccountEditor.role === roleKey;
                       return (
                         <button

--- a/apps/nomad-master-web/src/components/access/types.ts
+++ b/apps/nomad-master-web/src/components/access/types.ts
@@ -24,7 +24,7 @@ export const emptyStaffAccountEditor = (): StaffAccountEditorState => ({
   id: '',
   login: '',
   name: '',
-  role: 'nomad',
+  role: 'master',
   password: '',
   active: true,
 });

--- a/apps/nomad-master-web/src/contracts.test.ts
+++ b/apps/nomad-master-web/src/contracts.test.ts
@@ -668,7 +668,7 @@ test('normalizeDailyAccessCodeRecord preserves display code and dates', () => {
   });
 });
 
-test('normalizeStaffAccountRecord defaults to nomad role', () => {
+test('normalizeStaffAccountRecord defaults to master role', () => {
   const record = normalizeStaffAccountRecord({
     id: 'staff-1',
     login: 'nomad',
@@ -680,7 +680,7 @@ test('normalizeStaffAccountRecord defaults to nomad role', () => {
     id: 'staff-1',
     login: 'nomad',
     name: 'Кальянный мастер',
-    role: 'nomad',
+    role: 'master',
     active: true,
   });
 });
@@ -714,7 +714,7 @@ test('sortStaffAccounts keeps active admins first', () => {
       id: 'staff-2',
       login: 'nomad',
       name: 'Nomad',
-      role: 'nomad',
+      role: 'master',
       active: true,
     },
     {
@@ -728,7 +728,7 @@ test('sortStaffAccounts keeps active admins first', () => {
       id: 'staff-3',
       login: 'guest',
       name: 'Guest',
-      role: 'nomad',
+      role: 'master',
       active: false,
     },
   ]);

--- a/apps/nomad-master-web/src/contracts.ts
+++ b/apps/nomad-master-web/src/contracts.ts
@@ -1,7 +1,7 @@
 export type StaffUser = {
   login: string;
   name: string;
-  role: 'admin' | 'nomad';
+  role: 'admin' | 'master';
 };
 
 export type StaffAuthResponse = {
@@ -731,7 +731,7 @@ export const normalizeStaffAccountRecord = (value: unknown): StaffAccountRecord 
     id: String(raw.id ?? raw.accountId ?? ''),
     login: String(raw.login ?? ''),
     name: String(raw.name ?? ''),
-    role: raw.role === 'admin' ? 'admin' : 'nomad',
+    role: raw.role === 'admin' ? 'admin' : 'master',
     active: toBoolean(raw.active, true),
   };
 };
@@ -813,7 +813,7 @@ export const normalizeAuditEventRecord = (value: unknown): AuditEventRecord => {
     id: String(raw.id ?? ''),
     actorLogin: String(raw.actorLogin ?? ''),
     actorName: String(raw.actorName ?? ''),
-    actorRole: raw.actorRole === 'admin' ? 'admin' : 'nomad',
+    actorRole: raw.actorRole === 'admin' ? 'admin' : 'master',
     action,
     entityType,
     entityId: String(raw.entityId ?? ''),
@@ -1325,7 +1325,7 @@ export const sortDailyAccessCodes = (items: DailyAccessCodeRecord[]) => {
 export const sortStaffAccounts = (items: StaffAccountRecord[]) => {
   const roleRank: Record<StaffUser['role'], number> = {
     admin: 0,
-    nomad: 1,
+    master: 1,
   };
 
   const copy = [...items];

--- a/tests/nomad-smoke/tests/master-smoke.spec.ts
+++ b/tests/nomad-smoke/tests/master-smoke.spec.ts
@@ -165,7 +165,7 @@ test('Master admin smoke covers inventory batch flow, mixes editor, rails read-o
   await expect(page.getByText('Что происходило в системе')).toHaveCount(0);
 });
 
-test('Master nomad role keeps admin-only surfaces restricted while preserving access context', async ({ page }) => {
+test('Master non-admin role keeps admin-only surfaces restricted while preserving access context', async ({ page }) => {
   await signIn('nomad', 'nomad', page);
 
   await openWorkspace(page, 'Доступ');


### PR DESCRIPTION
## Что и зачем

Этап 2 отвязки от бренда **Nomad**: убираем «Nomad» из **моделей данных** и значения роли персонала, делая контур самостоятельным («Арома Ателье»). Снят префикс у всех 18 Prisma-моделей и переименовано значение роли `'nomad'` → `'master'`.

> ⚠️ **Требует человеческого ревью** — затронуты `prisma/**` (схема + миграция) и auth-пути (роль). Self-merge неприменим.

## Миграция БД — безопасность

`prisma/migrations/20260622000000_strip_nomad_prefix` — **только метаданные, без перезаписи данных**:
- `ALTER TABLE … RENAME TO` ×18 (таблицы);
- `ALTER TABLE … RENAME CONSTRAINT` ×24 (pkey + fkey);
- `ALTER INDEX … RENAME TO` ×32 (unique + secondary);
- `UPDATE "StaffAccount" SET role='master' WHERE role='nomad'` (data-миграция роли).

**Валидация:** replay `init → strip` на чистой БД через `migrate deploy` + `prisma migrate diff (datasource ↔ datamodel)` → **«No difference detected»** (объекты БД точно совпадают с ожиданиями Prisma для новых имён, нулевой дрейф). Переименования таблиц/индексов — операции каталога, мгновенные.

**Прод:** миграция применяется к живой БД на Этапе 5 (катовер) — со снапшотом и атомарным редеплоем backend. Имя БД на проде (`default_db`) не трогается.

## Код

- **backend** (~211 правок): `prisma.nomadX` → `prisma.x` во всех `src/**`, `scripts/**`, `seed.ts`; роль `'nomad'`→`'master'` в `auth.ts`/`access.ts`/`audit.ts`/`types.ts`/`state.ts`/`seed.ts` и backend-тестах. Внутренние type-алиасы (`NomadStorageTx`, `NomadRailType`, `NomadDailyCodeWindow`, `NomadTaxonomyCandidate`, `NomadCatalogPreview`) и локальная `.nomadCandidate` — это НЕ модели данных, оставлены (общий код-деном — Этап 3).
- **master-web** (11 правок): тип/значение роли `'admin' | 'master'` в `contracts.ts`, `App.tsx`, `staff-block.tsx`, `access/types.ts`, `contracts.test.ts`.
- **smoke:** уточнён заголовок теста роли; демо-логин/пароль `'nomad'` сохранены (smoke `signIn('nomad','nomad')` не ломается — меняется только значение поля role, ассертов на лейбл роли нет).

## Проверки

- `apps/nomad-backend`: `npm test` **52/52**, `npm run build` зелёный.
- `apps/nomad-master-web`: `npm test` **44/44**, `npm run build` зелёный.
- Миграция: `migrate diff` — нулевой дрейф (см. выше).
- `nomad-smoke` — на CI.

## Вне scope

Демо-логин `'nomad'`, `STORAGE_KEY 'nomad-master-auth-v1'`, тест-фикстуры `'Nomad Reserve'`, внутренние type-алиасы, имена каталогов/инфра — Этапы 3–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)