### PR TITLE
fix(backend): убрать флак ротации daily-code (коллизия кода)

### DIFF
--- a/apps/backend/src/access.ts
+++ b/apps/backend/src/access.ts
@@ -644,16 +644,20 @@ export const rotateCurrentDailyAccessCode = async () => {
   const window = getNomadDailyCodeWindow();
 
   return prisma.$transaction(async (tx) => {
-    const records = await tx.dailyAccessCode.findMany({
-      where: dailyCodeWindowFilter(window),
-      orderBy: [{ createdAt: 'desc' }, { updatedAt: 'desc' }],
+    const windowRecords = await tx.dailyAccessCode.findMany({
+      where: {
+        startsAt: { lt: window.endsAt },
+        endsAt: { gt: window.startsAt },
+      },
+      select: { id: true, codeValue: true, active: true },
     });
 
-    if (records.length) {
+    const activeIds = windowRecords.filter((record) => record.active).map((record) => record.id);
+    if (activeIds.length) {
       await tx.dailyAccessCode.updateMany({
         where: {
           id: {
-            in: records.map((record) => record.id),
+            in: activeIds,
           },
         },
         data: {
@@ -662,7 +666,10 @@ export const rotateCurrentDailyAccessCode = async () => {
       });
     }
 
-    const codeValue = createNomadDailyCodeValue(window.startsAt);
+    const codeValue = createNomadDailyCodeValue(
+      window.startsAt,
+      windowRecords.map((record) => record.codeValue),
+    );
     const secret = createAutomationSecret(codeValue);
     const created = await tx.dailyAccessCode.create({
       data: {

--- a/apps/backend/src/daily-code.test.ts
+++ b/apps/backend/src/daily-code.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createNomadDailyCodeValue } from './daily-code';
+
+test('createNomadDailyCodeValue produces a 4-digit code', () => {
+  const value = createNomadDailyCodeValue();
+  assert.match(value, /^\d{4}$/);
+});
+
+test('createNomadDailyCodeValue never returns an excluded code', () => {
+  const all = Array.from({ length: 10_000 }, (_, index) => index.toString().padStart(4, '0'));
+  const free = '4242';
+  const exclude = all.filter((code) => code !== free);
+
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    assert.equal(createNomadDailyCodeValue(new Date(), exclude), free);
+  }
+});

--- a/apps/backend/src/daily-code.ts
+++ b/apps/backend/src/daily-code.ts
@@ -23,5 +23,14 @@ export const getNomadDailyCodeWindow = (referenceDate = new Date()): NomadDailyC
   };
 };
 
-export const createNomadDailyCodeValue = (_referenceDate: Date = new Date()) =>
-  crypto.randomInt(0, 10000).toString().padStart(4, '0');
+export const createNomadDailyCodeValue = (
+  _referenceDate: Date = new Date(),
+  exclude: Iterable<string> = [],
+) => {
+  const taken = new Set(exclude);
+  let value = crypto.randomInt(0, 10000).toString().padStart(4, '0');
+  while (taken.has(value)) {
+    value = crypto.randomInt(0, 10000).toString().padStart(4, '0');
+  }
+  return value;
+};


### PR DESCRIPTION
## Контекст

В `apps/backend/src/automation.test.ts` тест «automation can read, ensure and rotate the current daily code» флакал на `assert.notEqual(rotatedBody.item.codeValue, currentBody.item.codeValue)` (наблюдалось на CI в #3).

Причина: ротация генерировала случайный 4-значный код без проверки на коллизию. С вероятностью ~1/9000 новый код совпадал с прежним. Помимо флака теста, совпадение с любым кодом окна (включая уже деактивированные) привело бы к падению `create` на уникальном `id = daily-code-<value>` → 500.

## Решение (вариант «а» — продуктово корректный)

- `createNomadDailyCodeValue(referenceDate, exclude?)` принимает множество исключаемых кодов и перегенерирует значение до уникального.
- `rotateCurrentDailyAccessCode` собирает **все** коды текущего окна (`active` и `inactive`) и передаёт их в `exclude`. Деактивируются по-прежнему только активные записи.

## Тесты

- Новый `apps/backend/src/daily-code.test.ts`: детерминированно проверяет, что при исключении 9999 из 10000 значений генератор всегда возвращает единственное свободное (50 прогонов).
- Прежний `automation.test.ts` без изменений — assert.notEqual теперь не флакает по построению.

## Gate

- `cd apps/backend && npm test` → 54 pass / 0 fail
- `npm run build` → чисто

Фронт (`*-web/src/**`) не затронут — smoke не требуется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)