### PR TITLE
chore(repo-ops): включить issue-workspace и дебрендинг governance-слоя

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -18,7 +18,7 @@ model: opus
 4. Определяешь write-scope каждой части и режим: один агент или параллельные
    (только при непересекающихся write-scope и зафиксированном контракте).
 5. Формируешь issue через `gh issue create` по шаблону из
-   `.github/ISSUE_TEMPLATE/` (`nomad-feature` / `nomad-bug` / `nomad-ops`).
+   `.github/ISSUE_TEMPLATE/` (`atelier-feature` / `atelier-bug` / `atelier-ops`).
 
 ## Правила
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Nomad-specific ownership
+# Ownership — Арома Ателье
 /apps/aroma-web/ @MelnikovTimofey
 /apps/master-web/ @MelnikovTimofey
 /apps/backend/ @MelnikovTimofey

--- a/.github/ISSUE_TEMPLATE/atelier-bug.yml
+++ b/.github/ISSUE_TEMPLATE/atelier-bug.yml
@@ -1,8 +1,7 @@
-name: "Nomad Bug"
-description: "Баг в Nomad UI, backend или bot"
-title: "[Nomad Bug] "
+name: "Арома Ателье · Bug"
+description: "Баг в UI, backend или боте Арома Ателье"
+title: "[bug] "
 labels:
-  - "contour:nomad"
   - "type:bug"
 body:
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/atelier-feature.yml
+++ b/.github/ISSUE_TEMPLATE/atelier-feature.yml
@@ -1,14 +1,13 @@
-name: "Nomad Feature Slice"
-description: "Новый bounded feature slice для Nomad"
-title: "[Nomad] "
+name: "Арома Ателье · Feature Slice"
+description: "Новый bounded feature slice для Арома Ателье"
+title: "[feat] "
 labels:
-  - "contour:nomad"
   - "type:feature"
 body:
   - type: markdown
     attributes:
       value: |
-        Базовый intake flow для Nomad feature work:
+        Базовый intake flow для feature work Арома Ателье:
         - для bounded feature slice использовать этот шаблон как source of truth;
         - этот issue фиксирует bounded context, scope и проверки до написания кода;
         - для UI/redesign задач в `apps/master-web` обязательно заполнить `Design / UX baseline`.

--- a/.github/ISSUE_TEMPLATE/atelier-ops.yml
+++ b/.github/ISSUE_TEMPLATE/atelier-ops.yml
@@ -1,8 +1,7 @@
-name: "Nomad Ops / Runtime"
-description: "Env, deploy, runtime, bot или release задача для Nomad"
-title: "[Nomad Ops] "
+name: "Арома Ателье · Ops / Runtime"
+description: "Env, deploy, runtime, bot или release задача для Арома Ателье"
+title: "[ops] "
 labels:
-  - "contour:nomad"
   - "type:ops"
 body:
   - type: dropdown
@@ -14,7 +13,7 @@ body:
         - "apps/aroma-web"
         - "apps/master-web"
         - "services/telegram-bot"
-        - "cross-surface Nomad ops"
+        - "cross-surface ops"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Правила процесса (CLAUDE.md)"
+    url: "https://github.com/MelnikovTimofey/yummy/blob/main/CLAUDE.md"
+    about: "Issue → ветка → PR, TDD, self-merge — прочитать перед заведением задачи."

--- a/.github/NOMAD_REVIEW_POLICY.md
+++ b/.github/NOMAD_REVIEW_POLICY.md
@@ -1,19 +1,24 @@
-# Nomad Review Policy
+# Review Policy — Арома Ателье
+
+> Имя файла (`NOMAD_REVIEW_POLICY.md`) и CI-идентификаторы (`nomad-review-flags`,
+> `nomad-smoke`, `nomad-*-build`) сохранены как функциональные идентификаторы —
+> на них завязаны CLAUDE.md, required-checks и branch protection. Переименование
+> человекочитаемого слоя не трогает эти идентификаторы намеренно.
 
 ## Назначение
 
-Этот документ фиксирует GitHub-layer для репозитория Nomad.
+Этот документ фиксирует GitHub-layer репозитория Арома Ателье.
 
 Цель:
 
-1. структурировать входящие Nomad issues;
-2. стандартизировать Nomad PR review;
-3. запускать автоматические проверки только по Nomad active scope;
+1. структурировать входящие issues;
+2. стандартизировать PR review;
+3. запускать автоматические проверки только по active scope изменения;
 4. вводить enforcement поэтапно, не ломая текущий `Human Review` workflow.
 
 ## Base branch
 
-Для Nomad PR использовать base branch `main` — production-ветка репозитория.
+Использовать base branch `main` — production-ветка репозитория.
 
 ## Branch naming
 
@@ -26,7 +31,7 @@ Slug — короткое имя в kebab-case (например `feature/master
 
 ## PR shape
 
-Для Nomad действует правило:
+Действует правило:
 
 1. `1 PR = 1 bounded context = 1 проверяемый результат`
 
@@ -37,13 +42,14 @@ Slug — короткое имя в kebab-case (например `feature/master
 
 ## Issue shape
 
-Для Nomad feature work базовым intake path считается:
+Базовым intake path для feature work считается:
 
-1. `.github/ISSUE_TEMPLATE/nomad-feature.yml`
+1. `.github/ISSUE_TEMPLATE/atelier-feature.yml`
 
 Каждая нетривиальная задача начинается с issue до написания кода.
+Blank issues отключены (`config.yml`) — задача заводится только по шаблону.
 
-Каждый Nomad feature issue должен зафиксировать:
+Каждый feature issue должен зафиксировать:
 
 1. `Primary scope`
 2. `Problem`
@@ -62,9 +68,9 @@ Slug — короткое имя в kebab-case (например `feature/master
 
 ## Required PR fields
 
-Каждый Nomad PR обязан содержать:
+Каждый PR обязан содержать:
 
-1. `Contour: Nomad`
+1. `Closes #<issue>` — ссылка на закрываемый issue (1 PR = 1 issue)
 2. `Bounded context`
 3. `Touched paths`
 4. `Write scope`
@@ -79,7 +85,7 @@ Slug — короткое имя в kebab-case (например `feature/master
 PR должен считаться `needs-human-review`, если затронуто хотя бы одно из условий:
 
 1. `apps/backend/prisma/**`
-2. Nomad auth-related backend files:
+2. auth-related backend files:
    - `apps/backend/src/auth.ts`
    - `apps/backend/src/auth.test.ts`
    - `apps/backend/src/access.ts`
@@ -105,13 +111,14 @@ PR должен считаться `needs-human-review`, если затрону
 
 Source of truth по GitHub labels хранится в `.github/labels.md`.
 
-Минимальный Nomad set:
+Минимальный set:
 
-1. `contour:nomad`
-2. `type:*`
-3. `scope:*`
-4. `risk:*`
-5. `batch:*`
+1. `type:*`
+2. `scope:*`
+3. `risk:*`
+4. `batch:*` (дублируется milestone'ом)
+
+Метка `contour:nomad` — legacy (см. `labels.md`), на новые issue/PR не навешивается.
 
 ## Phase rollout
 
@@ -119,15 +126,15 @@ Source of truth по GitHub labels хранится в `.github/labels.md`.
 
 Включить:
 
-1. issue templates для Nomad как базовый intake path;
-2. PR template для Nomad;
-3. `CODEOWNERS` для Nomad paths;
-4. Nomad-only GitHub Actions;
+1. issue templates как базовый intake path;
+2. PR template;
+3. `CODEOWNERS` для process paths;
+4. GitHub Actions по scope изменения;
 5. ручное создание labels в GitHub UI или через CLI.
 
 Не включать пока:
 
-1. auto-merge для Nomad;
+1. auto-merge;
 2. branch protection, если required checks ещё нестабильны.
 
 ### Phase 2
@@ -135,9 +142,14 @@ Source of truth по GitHub labels хранится в `.github/labels.md`.
 После стабилизации CI вручную включить branch protection или ruleset для `main`:
 
 1. require 1 approving review;
-2. require `CODEOWNERS` review для Nomad process files;
-3. require relevant Nomad checks;
+2. require `CODEOWNERS` review для process files;
+3. require relevant checks;
 4. не включать auto-merge до отдельного решения.
+
+> ⚠️ **Ограничение плана.** На приватном репозитории free-плана branch protection
+> API и rulesets недоступны (`403 Upgrade to GitHub Pro`). До перехода на Pro/Team
+> или публикации репозитория Phase 2 неисполним на GitHub-стороне — enforcement
+> держится на CI-гейтах и self-merge дисциплине (CLAUDE.md §5).
 
 Рекомендуемые required checks:
 
@@ -147,11 +159,11 @@ Source of truth по GitHub labels хранится в `.github/labels.md`.
 4. `nomad-bot-build`
 5. `nomad-smoke`
 
-Если используется GitHub ruleset с path targeting, применять эти checks только для Nomad paths.
+Если используется GitHub ruleset с path targeting, применять эти checks только для активных path.
 
 ## Docs sync
 
-Если GitHub governance для Nomad меняется, обновлять:
+Если GitHub governance меняется, обновлять:
 
 1. `CLAUDE.md`, если меняются правила агента, процесс или operating model
 2. `.claude/agents/` или `.claude/skills/`, если меняются роли или скиллы
@@ -163,5 +175,5 @@ Source of truth по GitHub labels хранится в `.github/labels.md`.
 Этот policy не нормализует пока:
 
 1. legacy `Yummy` GitHub governance;
-2. repo-wide branch protection для всех контуров;
-3. auto-merge стратегию для Nomad.
+2. repo-wide branch protection;
+3. auto-merge стратегию.

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -1,14 +1,13 @@
-# GitHub Labels For Nomad
+# GitHub Labels для Арома Ателье
 
-Этот файл является source of truth для Nomad labels в GitHub.
+Этот файл — source of truth для labels репозитория.
 
 ## Core labels
 
 | Label | Color | Description |
 |---|---|---|
-| `contour:nomad` | `0E8A16` | PR или issue относится к Nomad parallel track |
 | `type:feature` | `1D76DB` | Новый bounded feature slice |
-| `type:bug` | `D73A4A` | Баг в Nomad UI, backend или bot |
+| `type:bug` | `D73A4A` | Баг в UI, backend или боте |
 | `type:ops` | `5319E7` | Env, deploy, runtime, bot или release задача |
 | `type:docs` | `006B75` | Документация, workflow, process или handoff change |
 
@@ -31,20 +30,29 @@
 
 ## Batch labels
 
-| Label | Color | Description |
+Каждый батч дублируется milestone'ом (см. GitHub → Milestones) — метка помечает
+issue/PR, milestone даёт группировку и burndown.
+
+| Label | Milestone | Color |
 |---|---|---|
-| `batch:release-foundation` | `C5DEF5` | `Release Foundation` |
-| `batch:master-operations` | `BFDADC` | `Master Operations` |
-| `batch:analytics-and-rails` | `F9D0C4` | `Analytics And Rails` |
-| `batch:quality-and-hardening` | `D4C5F9` | `Quality And Hardening` |
-| `batch:aroma-polish` | `F7C6C7` | `Aroma Polish` |
+| `batch:release-foundation` | Release Foundation | `C5DEF5` |
+| `batch:master-operations` | Master Operations | `BFDADC` |
+| `batch:analytics-and-rails` | Analytics And Rails | `F9D0C4` |
+| `batch:quality-and-hardening` | Quality And Hardening | `D4C5F9` |
+| `batch:aroma-polish` | Aroma Polish | `F7C6C7` |
 
-## Manual creation example
+## Legacy labels (не навешивать на новые issue/PR)
 
-Если `gh` настроен, labels можно создать вручную командами вида:
+| Label | Причина |
+|---|---|
+| `contour:nomad` | Концепт «parallel track» рядом с legacy Yummy устарел после split (CLAUDE.md §6): контур один — Арома Ателье. Метка сохранена только на исторических PR #2–#5. |
+
+## Ручное создание
+
+Если `gh` настроен, labels создаются командами вида:
 
 ```bash
-gh label create "contour:nomad" --color "0E8A16" --description "PR или issue относится к Nomad parallel track"
+gh label create "type:feature" --color "1D76DB" --description "Новый bounded feature slice"
 ```
 
 Повторить для остальных labels из таблиц выше.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
-## Contour
+## Связанный issue
 
-- [ ] `Nomad`
+<!-- Обязательно. Каждый PR закрывает ровно один issue (1 PR = 1 bounded context). -->
+
+Closes #
 
 ## Bounded Context
 
@@ -8,13 +10,13 @@
 
 ## Touched Paths
 
-Перечислите изменённые Nomad-пути:
+Перечислите изменённые пути:
 
 - `apps/aroma-web/...`
 - `apps/master-web/...`
 - `apps/backend/...`
 - `services/telegram-bot/...`
-- `docs/process paths`, если были затронуты
+- `docs/` или process-пути, если были затронуты
 
 ## Write Scope
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,8 +134,9 @@ Production-ветка репозитория — `main`. Соглашение п
 >    свериться с ним и убедиться, что слот свободен.
 
 1. Нетривиальная задача начинается с GitHub issue
-   (`.github/ISSUE_TEMPLATE/nomad-feature.yml` / `nomad-bug.yml` / `nomad-ops.yml`).
-   Issue фиксирует bounded context, scope, критерии и проверки.
+   (`.github/ISSUE_TEMPLATE/atelier-feature.yml` / `atelier-bug.yml` / `atelier-ops.yml`).
+   Issue фиксирует bounded context, scope, критерии и проверки. Blank issues
+   отключены — задача заводится только по шаблону.
 2. Ветка от **свежего** `main` (после `git pull origin main`) по соглашению:
    - `feature/<slug>` — новый функционал, рефакторинг с продуктовым
      эффектом, обновление процесса/документации, новая поверхность;

--- a/docs/atelier/master-production-redesign.md
+++ b/docs/atelier/master-production-redesign.md
@@ -4,7 +4,7 @@
 
 Этот документ фиксирует contract-first пакет для преобразования `Мастер` из MVP в production-ready staff/admin контур.
 
-Каждый slice ведётся как отдельный GitHub issue по шаблону `.github/ISSUE_TEMPLATE/nomad-feature.yml`.
+Каждый slice ведётся как отдельный GitHub issue по шаблону `.github/ISSUE_TEMPLATE/atelier-feature.yml`.
 
 Документ нужен до начала широкого рефакторинга, чтобы:
 


### PR DESCRIPTION
## Связанный issue

Нет issue — это bootstrap самого issue-workspace (первая задача, включающая процесс через issues). Дальнейшие задачи будут заводиться из шаблона.

## Bounded Context

Включение GitHub issue-workspace как рабочего пространства команды + дебрендинг человекочитаемого governance-слоя (Nomad → Арома Ателье). Не меняет код приложений, схему, auth или runtime.

## Что сделано

**Issue-workspace (реальная работа через issues):**
- `config.yml` — blank issues off, задача заводится только по шаблону
- PR-шаблон: секция `Contour` → обязательная связка `Closes #<issue>` (traceability, которой не было ни в одном из PR #1–#5)
- шаблоны `nomad-*.yml` → `atelier-*.yml` (git mv, история сохранена)

**Дебренд governance-слоя:**
- issue-шаблоны: тексты, заголовки (`[feat]`/`[bug]`/`[ops]`), дропдауны → Арома Ателье; убран авто-лейбл `contour:nomad`
- `labels.md`: пути `apps/nomad-*` → `apps/*`; батчи ↔ milestones; `contour:nomad` → legacy (концепт parallel-track умер после split legacy, CLAUDE.md §6)
- `NOMAD_REVIEW_POLICY.md`: проза → Арома Ателье; ссылка на `atelier-feature.yml`; **зафиксировано ограничение free-плана** — branch protection API недоступен (`403`), Phase 2 неисполним на GitHub-стороне
- живые ссылки на переименованные шаблоны обновлены: `CLAUDE.md`, `.claude/agents/planner.md`, `docs/atelier/master-production-redesign.md`
- `CODEOWNERS`: комментарий → Арома Ателье

**Сохранено намеренно (функциональные идентификаторы):** CI-ID `nomad-*-build`/`nomad-smoke`/`nomad-review-flags`, имя файла `NOMAD_REVIEW_POLICY.md`, креды БД `NOMAD_*` — на них завязаны required-checks и `CLAUDE.md`.

## GitHub-сторона (вне диффа, уже сделано)

- Созданы 5 milestones под батчи: Release Foundation, Master Operations, Analytics And Rails, Quality And Hardening, Aroma Polish.

## Touched Paths

`.github/**`, `CLAUDE.md`, `.claude/agents/planner.md`, `docs/atelier/master-production-redesign.md`

## Checks Run

```
ruby YAML.load_file(.github/**/*.yml) → OK (все 7 файлов)
git diff --check → whitespace clean
rg TODO/placeholder в диффе → новых маркеров нет
```

Кода приложений не трогает — build/test/smoke не применимы.

## Docs Updated

- [x] `CLAUDE.md` (ссылка на шаблоны + blank issues off)
- [x] `.claude/` (planner.md)
- [ ] `no docs changes required`

## Risks / Human Review Needed

Нужен **Human Review**: PR затрагивает `.github/**`, `CLAUDE.md`, `.claude/**` → process-governance по `NOMAD_REVIEW_POLICY.md`. Self-merge неприменим.

Наблюдение (вне scope): docs-lint грепает `TODO` по всему дереву `docs/`, включая замороженные архивы `docs/artifacts/archive/*`, где слово встречается в примерах команд. Локальный `rg` матчит их, но CI-прогоны исторически зелёные (расхождение среды). Если docs-lint покраснеет здесь — причина предсуществующая, не в этом диффе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)