### PR TITLE
chore(repo-ops): follow-ups — снять авто-contour:nomad и зафиксировать branch protection

### DIFF
--- a/.github/NOMAD_REVIEW_POLICY.md
+++ b/.github/NOMAD_REVIEW_POLICY.md
@@ -134,32 +134,36 @@ Source of truth по GitHub labels хранится в `.github/labels.md`.
 
 Не включать пока:
 
-1. auto-merge;
-2. branch protection, если required checks ещё нестабильны.
+1. auto-merge (self-merge выполняется вручную командой, см. CLAUDE.md §5.6);
+2. required status checks — до появления always-running gate-job (см. Phase 2).
 
-### Phase 2
+### Phase 2 — включено
 
-После стабилизации CI вручную включить branch protection или ruleset для `main`:
+Репозиторий публичный, на `main` включена branch protection:
 
-1. require 1 approving review;
-2. require `CODEOWNERS` review для process files;
-3. require relevant checks;
-4. не включать auto-merge до отдельного решения.
+1. **PR обязателен** для изменения `main` — прямой push/force-push/удаление запрещены;
+2. **`enforce_admins: true`** — правило связывает всех, включая владельца и агентов
+   (CLAUDE.md §5 «не писать в `main` напрямую» стало hard-гарантией);
+3. **required approving reviews = 0** — self-merge сохранён (CLAUDE.md §5.6): safe-PR
+   Claude мерджит сам, human review для risk-PR остаётся процедурным (label
+   `risk:human-review` + ожидание), не hard-gate.
 
-> ⚠️ **Ограничение плана.** На приватном репозитории free-плана branch protection
-> API и rulesets недоступны (`403 Upgrade to GitHub Pro`). До перехода на Pro/Team
-> или публикации репозитория Phase 2 неисполним на GitHub-стороне — enforcement
-> держится на CI-гейтах и self-merge дисциплине (CLAUDE.md §5).
+### Required status checks — пока НЕ включены
 
-Рекомендуемые required checks:
+Все воркфлоу используют path-фильтры (`on.paths` + `if: needs.changes...`), поэтому
+если пометить чек required, PR, не трогающий его пути, **навсегда зависнет** в
+ожидании чека, который не запустится. Прежде чем делать чеки required, нужен
+always-running aggregating gate-job (один чек, который всегда репортит и агрегирует
+результат остальных).
+
+Кандидаты в required (после появления gate-job):
 
 1. `nomad-aroma-build`
 2. `nomad-master-build`
 3. `nomad-backend-build`
 4. `nomad-bot-build`
 5. `nomad-smoke`
-
-Если используется GitHub ruleset с path targeting, применять эти checks только для активных path.
+6. `nomad-docs-lint`
 
 ## Docs sync
 

--- a/.github/workflows/nomad-pr-checks.yml
+++ b/.github/workflows/nomad-pr-checks.yml
@@ -75,7 +75,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - name: Apply available Nomad labels
+      - name: Apply available labels
         uses: actions/github-script@v7
         env:
           AROMA: ${{ needs.changes.outputs.aroma }}
@@ -98,7 +98,9 @@ jobs:
             });
             const existingNames = new Set(existing.map((label) => label.name));
 
-            const desired = new Set(["contour:nomad"]);
+            // contour:nomad — legacy (см. labels.md): parallel-track концепт умер
+            // после split legacy, на новые PR не навешиваем.
+            const desired = new Set();
             if (process.env.AROMA === "true") desired.add("scope:aroma-web");
             if (process.env.MASTER === "true") desired.add("scope:master-web");
             if (process.env.BACKEND === "true") desired.add("scope:backend");
@@ -144,7 +146,7 @@ jobs:
             }
 
             const summary = [
-              "## Nomad review flags",
+              "## Review flags",
               `Human review required: ${needsHumanReview ? "yes" : "no"}`,
               `Applied labels: ${addable.length > 0 ? addable.join(", ") : "none"}`,
               `Missing labels in repo settings: ${missing.length > 0 ? missing.join(", ") : "none"}`,


### PR DESCRIPTION
## Связанный issue

Follow-up к PR #6 (issue-workspace bootstrap). Два коммита из ветки #6 остались вне squash-merge и переносятся сюда с обновлённого `main`.

## Bounded Context

Governance follow-ups к включённому issue-workspace. Кода приложений/схемы/auth не трогает.

## Что сделано

1. **Снят авто-`contour:nomad`.** Job `nomad-review-flags` больше не вешает legacy-метку (концепт parallel-track умер после split legacy; `labels.md` помечает метку legacy). `scope:*`/`risk:*` без изменений; job-key `nomad-review-flags` сохранён (ID required-чека).
2. **Policy отражает включённую branch protection.** После публикации репозитория на `main` включена защита: PR обязателен, force-push/удаление запрещены, `enforce_admins: true`, аппрувы = 0 (self-merge сохранён). Устаревшая заметка «на free-плане недоступно» заменена. Зафиксировано, почему required-checks пока не включены (path-фильтры воркфлоу → deadlock без always-running gate-job).

## Touched Paths

`.github/workflows/nomad-pr-checks.yml`, `.github/NOMAD_REVIEW_POLICY.md`

## Checks Run

\`\`\`
ruby YAML.load_file(.github/**/*.yml) → OK
git diff --check → whitespace clean
\`\`\`

## Risks / Human Review Needed

Нужен **Human Review**: затрагивает `.github/**` (workflow + policy) → process-governance. Self-merge неприменим.

🤖 Generated with [Claude Code](https://claude.com/claude-code)