### PR TITLE
chore(repo-ops): убрать висячие ссылки на удалённую метку contour:nomad

### DIFF
--- a/.github/REVIEW_POLICY.md
+++ b/.github/REVIEW_POLICY.md
@@ -113,8 +113,6 @@ Source of truth по GitHub labels хранится в `.github/labels.md`.
 3. `risk:*`
 4. `batch:*` (дублируется milestone'ом)
 
-Метка `contour:nomad` — legacy (см. `labels.md`), на новые issue/PR не навешивается.
-
 ## Phase rollout
 
 ### Phase 1

--- a/.github/workflows/atelier-pr-checks.yml
+++ b/.github/workflows/atelier-pr-checks.yml
@@ -98,8 +98,6 @@ jobs:
             });
             const existingNames = new Set(existing.map((label) => label.name));
 
-            // contour:nomad — legacy (см. labels.md): parallel-track концепт умер
-            // после split legacy, на новые PR не навешиваем.
             const desired = new Set();
             if (process.env.AROMA === "true") desired.add("scope:aroma-web");
             if (process.env.MASTER === "true") desired.add("scope:master-web");


### PR DESCRIPTION
## Связанный issue

Без issue — хвост, замеченный при работе над #23 (вынесен из того PR, чтобы не смешивать bounded context).

## Bounded Context

Метка `contour:nomad` удалена в #12, запись из `labels.md` тоже снята. Две ссылки на неё остались и указывали на несуществующий объект.

## Изменения
- `.github/REVIEW_POLICY.md` — снята строка «Метка `contour:nomad` — legacy…».
- `.github/workflows/atelier-pr-checks.yml` — снят комментарий, объяснявший пустой `const desired = new Set()`. После удаления метки пустое множество самоочевидно, а метки добавляются условиями ниже (CLAUDE.md §2: комментарий — только когда «почему» неочевидно).

Поведение workflow не меняется — правится только комментарий.

## Checks
`rg --hidden "contour:nomad"` → пусто; метки нет и на GitHub; YAML `.github/**` валиден; whitespace чисто.

## Risks / Human Review
Затрагивает `.github/**` → сработает `risk:human-review`. Изменение — только текст и комментарий.

🤖 Generated with [Claude Code](https://claude.com/claude-code)