### PR TITLE
feat(master-web): единая иконка огонька в метриках каталога миксов

### DIFF
--- a/apps/master-web/src/components/mixes/mix-catalog-view.tsx
+++ b/apps/master-web/src/components/mixes/mix-catalog-view.tsx
@@ -1,5 +1,16 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronDown, Copy, Eye, EyeOff, Pencil, Plus, Search, Trash2 } from 'lucide-react';
+import {
+  ChevronDown,
+  Copy,
+  Eye,
+  EyeOff,
+  Flame,
+  Pencil,
+  Plus,
+  Search,
+  Star,
+  Trash2,
+} from 'lucide-react';
 import {
   Dialog,
   DialogClose,
@@ -507,10 +518,12 @@ export const MixCatalogView = ({
                       <td>
                         <div className="mixes-cell mixes-cell__metrics">
                           <span className="mixes-cell__metric" title="Популярность микса">
-                            <span aria-hidden="true">🔥</span> {formatMetricValue(mix.smokeCtaCount)}
+                            <Flame size={11} aria-hidden="true" />
+                            {formatMetricValue(mix.smokeCtaCount)}
                           </span>
                           <span className="mixes-cell__metric" title="Средний рейтинг гостей">
-                            <span aria-hidden="true">★</span> {mix.avgRating.toFixed(1)}
+                            <Star size={11} aria-hidden="true" />
+                            {mix.avgRating.toFixed(1)}
                             {mix.ratingsCount > 0 ? (
                               <span className="mixes-cell__metric-meta">
                                 ({formatMetricValue(mix.ratingsCount)})


### PR DESCRIPTION
## Связанный issue

Closes #28

## Bounded Context

Визуальная унификация метрик спроса и рейтинга в каталоге миксов `apps/master-web`: эмодзи 🔥 и текстовый глиф ★ заменены на lucide-иконки `Flame` и `Star`, идентичные тем, что уже используются на дашборде.

Эмодзи зависит от системного шрифта, приходит цветным и не наследует `currentColor` — в тёмной теме Film Noir выбивался из строки метрик. Одна и та же величина (`smokeCtaCount`) выглядела по-разному на двух соседних экранах backoffice.

Звезда переведена заодно: после замены одного огонька в ячейке остался бы SVG рядом с текстовым глифом.

## Touched Paths

- `apps/master-web/src/components/mixes/mix-catalog-view.tsx`

## Write Scope

Один файл, две правки: импорт `Flame`/`Star` из `lucide-react` и разметка ячейки `.mixes-cell__metrics`. Текстовый пробел между иконкой и значением убран — отступ даёт `gap: 4px` у `.mixes-cell__metric`, как у `.dashboard-page__metric`.

Вне scope: `inventory-view` и `rail-editor` (выделены в #26), `styles.css`, backend-контракт, смысл и расчёт метрики.

## Checks Run

```bash
cd apps/master-web && npm test          # 44 pass, 0 fail
cd apps/master-web && npm run build     # ✓ built
cd tests/smoke && npm run smoke         # 4 passed
```

Дополнительно проверено в браузере: в DOM `lucide lucide-flame` и `lucide lucide-star`, оба 11px, текстовых глифов не осталось, консоль без ошибок.

Заметка по smoke: первый прогон дал 2 падения, проверка через `git stash` показала, что те же тесты падают на чистом `main` — причины в состоянии окружения (продуктовый снапшот вместо демо-seed и устаревший `VITE_API_BASE_URL` в локальном gitignored `.env.local`), а не в этом изменении. Зелёный прогон получен на демо-seed по документированному в README порядку. Проблема зависимости smoke от фикстур вынесена в #27.

## Docs Updated

- [ ] `CLAUDE.md`
- [ ] `.claude/` (агенты или скиллы)
- [ ] `README.md`
- [x] `no docs changes required`

## Risks / Human Review Needed

1. Остаточные риски: минимальные. Изменение чисто презентационное, доступное имя не менялось — `aria-hidden` на обеих иконках, `title` ячеек прежние. Значения и форматирование (`formatMetricValue`, `toFixed(1)`, счётчик оценок в скобках) не тронуты.
2. `Human Review` не требуется.
3. Категории: ни одна не применима — schema/auth/env/runtime не затронуты, публичный контракт не меняется, process/workflow/skills не затрагиваются, верификация полная (unit + build + smoke).