### PR TITLE
feat(master-web): палитра консоли по канону вместо oklch-приближения

### DIFF
--- a/apps/aroma-web/src/design-tokens.generated.css
+++ b/apps/aroma-web/src/design-tokens.generated.css
@@ -74,6 +74,7 @@
   --warning-soft: rgba(194, 162, 78, 0.15);
   --danger: #cf4f44;
   --danger-soft: rgba(207, 79, 68, 0.15);
+  --danger-border: rgba(207, 79, 68, 0.4);
   --info: #5e7e96;
   --info-soft: rgba(94, 126, 150, 0.15);
 

--- a/apps/master-web/src/design-tokens.generated.css
+++ b/apps/master-web/src/design-tokens.generated.css
@@ -74,6 +74,7 @@
   --warning-soft: rgba(194, 162, 78, 0.15);
   --danger: #cf4f44;
   --danger-soft: rgba(207, 79, 68, 0.15);
+  --danger-border: rgba(207, 79, 68, 0.4);
   --info: #5e7e96;
   --info-soft: rgba(94, 126, 150, 0.15);
 

--- a/apps/master-web/src/styles.css
+++ b/apps/master-web/src/styles.css
@@ -15,37 +15,10 @@
   color-scheme: dark;
   font-family: "IBM Plex Sans Variable", "Geist Variable", "Avenir Next", "Segoe UI", sans-serif;
 
-  /* ─── Film Noir palette (smoky charcoal, single oxblood accent) ─── */
-  --bg-base: oklch(0.205 0.005 285);
-  --bg-raised: oklch(0.255 0.006 285);
-  --bg-elevated: oklch(0.295 0.007 285);
-  --bg-overlay: oklch(0.335 0.008 285);
-
-  --border-subtle: oklch(0.66 0.005 90 / 0.16);
-  --border-default: oklch(0.66 0.005 90 / 0.26);
-  --border-strong: oklch(0.66 0.005 90 / 0.40);
-
-  --text-primary: oklch(0.92 0.004 90);
-  --text-secondary: oklch(0.76 0.004 90);
-  --text-muted: oklch(0.62 0.004 90);
-  --text-faint: oklch(0.49 0.004 90);
-
-  --accent: oklch(0.56 0.13 32);
-  --accent-hover: oklch(0.62 0.14 32);
-  --accent-soft: oklch(0.56 0.13 32 / 0.15);
-  --accent-border: oklch(0.56 0.13 32 / 0.40);
-  --accent-fg: oklch(0.96 0.004 90);
-
-  --success: oklch(0.66 0.07 145);
-  --success-soft: oklch(0.66 0.07 145 / 0.15);
-  --warning: oklch(0.73 0.10 85);
-  --warning-soft: oklch(0.73 0.10 85 / 0.15);
-  --danger: oklch(0.60 0.17 28);
-  --danger-soft: oklch(0.60 0.17 28 / 0.15);
-  --info: oklch(0.62 0.05 240);
-  --info-soft: oklch(0.62 0.05 240 / 0.15);
-
-  --glass: oklch(0.255 0.006 285 / 0.82);
+  /* ─── Film Noir palette ───
+     Поверхности, текст, акцент-оксблад, бордеры и семантика приходят из
+     packages/design-tokens/colors.css (design-tokens.generated.css выше).
+     Локальных копий здесь нет: значение правится в пакете. */
 
   --r-xs: 4px;
   --r-sm: 6px;
@@ -76,46 +49,20 @@
   --fs-2xl: 28px;
   --fs-3xl: 36px;
 
-  --shadow-sm: 0 1px 0 0 oklch(0 0 0 / 0.4);
-  --shadow-md: 0 6px 24px -8px oklch(0 0 0 / 0.55), 0 1px 0 0 oklch(0 0 0 / 0.4);
-  --shadow-lg: 0 24px 60px -20px oklch(0 0 0 / 0.7), 0 2px 0 0 oklch(0 0 0 / 0.45);
-
-  /* ─── Legacy/shadcn aliases mapped to mockup tokens ─── */
+  /* ─── Локальные алиасы консоли ───
+     shadcn-контракт (--background, --card, --primary, --chart-*, --ring, …)
+     и --cta-gradient приходят из канона; здесь только то, чего в нём нет. */
   color: var(--text-primary);
   background: var(--bg-base);
 
   --accent-copper: var(--accent);
   --accent-sand: var(--accent-hover);
   --border-warm: var(--border-default);
-  --surface-glass: oklch(0.92 0.004 90 / 0.05);
-  --cta-gradient: linear-gradient(135deg, var(--accent), oklch(0.45 0.12 30));
+  --surface-glass: rgba(232, 230, 224, 0.05);
   --cta-shadow: var(--shadow-md);
   --danger-ink: var(--danger);
   --danger-surface: var(--danger-soft);
-  --danger-border: var(--accent-border);
-  --background: var(--bg-base);
-  --foreground: var(--text-primary);
-  --card: var(--bg-raised);
-  --card-foreground: var(--text-primary);
-  --popover: var(--bg-elevated);
-  --popover-foreground: var(--text-primary);
-  --primary: var(--accent);
-  --primary-foreground: var(--accent-fg);
-  --secondary: var(--bg-raised);
-  --secondary-foreground: var(--text-primary);
-  --muted: var(--bg-raised);
-  --muted-foreground: var(--text-muted);
   --accent-foreground: var(--text-primary);
-  --destructive: var(--danger);
-  --border: var(--border-subtle);
-  --input: oklch(0.92 0.004 90 / 0.07);
-  --ring: var(--accent-border);
-  --chart-1: oklch(0.56 0.13 32);
-  --chart-2: oklch(0.66 0.07 145);
-  --chart-3: oklch(0.62 0.05 240);
-  --chart-4: oklch(0.73 0.10 85);
-  --chart-5: oklch(0.55 0.01 285);
-  --radius: 0.625rem;
   --font-display: var(--font-serif);
   --sidebar: var(--bg-raised);
   --sidebar-foreground: var(--text-primary);
@@ -3856,11 +3803,6 @@ input[type="checkbox"] {
   --border: var(--border-subtle);
   --input: var(--input);
   --ring: var(--accent-border);
-  --chart-1: oklch(0.56 0.13 32);
-  --chart-2: oklch(0.66 0.07 145);
-  --chart-3: oklch(0.62 0.05 240);
-  --chart-4: oklch(0.73 0.10 85);
-  --chart-5: oklch(0.55 0.01 285);
   --sidebar: var(--bg-raised);
   --sidebar-foreground: var(--text-primary);
   --sidebar-primary: var(--accent);

--- a/packages/design-tokens/colors.css
+++ b/packages/design-tokens/colors.css
@@ -34,6 +34,7 @@
   --warning-soft: rgba(194, 162, 78, 0.15);
   --danger: #cf4f44;
   --danger-soft: rgba(207, 79, 68, 0.15);
+  --danger-border: rgba(207, 79, 68, 0.4);
   --info: #5e7e96;
   --info-soft: rgba(94, 126, 150, 0.15);
 


### PR DESCRIPTION
## Связанный issue

Closes #39

## Bounded Context

Палитра консоли Мастера. Только цвет: раскладка, разметка, тексты и шкалы не тронуты.

## Touched Paths

- `apps/master-web/src/styles.css` — локальные копии палитры удалены из `:root` и из мёртвого блока `.dark`
- `packages/design-tokens/colors.css` — добавлен `--danger-border`
- `apps/*/src/design-tokens.generated.css` — перегенерированы (`node packages/design-tokens/sync.mjs`)

## Write Scope

Консоль больше не держит собственных значений палитры — они приходят из канона. В локальном `:root` осталось только то, чего в пакете нет: `--accent-copper`, `--accent-sand`, `--border-warm`, `--surface-glass`, `--cta-shadow`, `--danger-ink`, `--danger-surface`, `--accent-foreground`, `--sidebar-*` и шкалы консоли (`--r-*`, `--space-*`, `--fs-*`).

Значения в живой странице после правки:

| токен | было (oklch → sRGB) | стало |
|---|---|---|
| `--bg-base` | `#171719` | `#141417` |
| `--bg-raised` | `#222226` | `#1C1C21` |
| `--bg-elevated` | `#2C2C30` | `#232329` |
| `--text-primary` | `#E5E4E2` | `#E8E6E0` |
| `--text-muted` | `#878683` | `#8F8D87` |
| `--accent` | `#B45341` | `#B04A3E` |
| `--accent-hover` | `#CC624E` | `#C25749` |
| `--success` / `--warning` / `--danger` / `--info` | `#779E78` / `#C5A35A` / `#D24D42` / `#6B8BA2` | `#6E9A6A` / `#C2A24E` / `#CF4F44` / `#5E7E96` |
| `--chart-5` | `oklch(0.55 0.01 285)` | `#8B8B90` |

Попутно снято две ошибки:

- `--danger-border: var(--accent-border)` — danger-блоки (`styles.css:531`, `:1282`) обводились **акцентным** оксбладом. Теперь `--danger-border: rgba(207, 79, 68, 0.4)` в каноне, то есть производная от `--danger`.
- `--cta-gradient` заканчивался на `oklch(0.45 0.12 30)` (≈ `#82372A`) вместо канонического `#7E342B` — унаследован из пакета.

Удалены и локальные `--shadow-sm/md/lg`: канон задаёт их теми же значениями через `rgba()`, дубликат только создавал риск дрейфа.

Контраст на новых поверхностях (посчитан в живой странице, WCAG 2.1 на `--bg-raised`):

```
--text-primary    13.60:1     --text-muted   5.11:1
--text-secondary   8.19:1     --text-faint   3.05:1
--accent-fg на --accent  4.72:1
```

**Вне scope:** типографика и monospace (#40), фавикон и знак (#43), гостевая поверхность (#41, #42).

## Checks Run

```bash
cd apps/master-web && npm test     # ✓ 44 теста
cd apps/master-web && npm run build # ✓ 2.14s
node packages/design-tokens/sync.mjs --check  # ✓ синхронны
```

Визуально: консоль поднята локально, снят экран входа — уголь, оксбладный CTA, hairline-бордеры на месте, ошибок в консоли браузера нет. Значения всех токенов палитры сверены в `getComputedStyle` живой страницы, не только в собранном CSS.

**Чего не сделал:** скриншотов Дашборда, Табаков и Доступа нет — для них нужен backend, а локальный Postgres не поднимается (docker daemon не запущен), поэтому и локальный smoke не прогонялся. Палитра при этом глобальная: все экраны берут те же переменные, значения которых сверены. Функциональную проверку делает `atelier-smoke` на CI.

## Docs Updated

- [ ] `CLAUDE.md`
- [ ] `.claude/` (агенты или скиллы)
- [ ] `README.md`
- [x] `no docs changes required`

## Risks / Human Review Needed

1. **Риски.** Поверхности стали темнее на 6–11 пунктов, а акцент — глубже: это и есть цель, но изменение видно на каждом экране, и Дашборд с Табаками я вижу только через CI-smoke, без глаз. Отдельно замечено, но **не** правилось в этом PR: блок `.dark` (`styles.css:3787+`) мёртв — класс `dark` нигде не навешивается, а внутри него есть самоссылка `--input: var(--input)`; там же `--accent: var(--bg-elevated)` перебивает бренд-акцент, если класс когда-нибудь появится. Оформлено отдельной задачей.
2. **Human Review не нужен** — process-, schema-, auth- и runtime-пути не затронуты.
3. **Категория:** ни одна из перечисленных.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
