### PR TITLE
feat(master-web): служебный слой на IBM Plex Sans вместо monospace

### DIFF
--- a/apps/master-web/package-lock.json
+++ b/apps/master-web/package-lock.json
@@ -8,8 +8,6 @@
       "name": "master-web",
       "version": "0.1.0",
       "dependencies": {
-        "@fontsource-variable/fraunces": "^5.2.9",
-        "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@fontsource-variable/source-serif-4": "^5.2.9",
         "@tailwindcss/vite": "^4.2.2",
@@ -1070,24 +1068,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
-    },
-    "node_modules/@fontsource-variable/fraunces": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/fraunces/-/fraunces-5.2.9.tgz",
-      "integrity": "sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource-variable/geist": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.8.tgz",
-      "integrity": "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
     },
     "node_modules/@fontsource-variable/ibm-plex-sans": {
       "version": "5.2.8",

--- a/apps/master-web/package.json
+++ b/apps/master-web/package.json
@@ -10,8 +10,6 @@
     "preview": "vite preview --host 0.0.0.0 --port 4175"
   },
   "dependencies": {
-    "@fontsource-variable/fraunces": "^5.2.9",
-    "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@fontsource-variable/source-serif-4": "^5.2.9",
     "@tailwindcss/vite": "^4.2.2",

--- a/apps/master-web/src/components/shell/master-page-header.tsx
+++ b/apps/master-web/src/components/shell/master-page-header.tsx
@@ -1,15 +1,15 @@
 import type { ReactNode } from 'react';
 
 type MasterPageHeaderProps = {
-  /** eyebrow uppercase mono mini (e.g. «ИНВЕНТАРИЗАЦИЯ», «МЕНЕДЖЕР МИКСОВ») */
+  /** eyebrow — служебный слой: uppercase 11px, --font-meta (e.g. «ИНВЕНТАРИЗАЦИЯ») */
   eyebrow?: string;
-  /** Main page title — рендерится как `<h1>` Fraunces огромный */
+  /** Main page title — рендерится как `<h1>` Source Serif 4, 36px/1.05 */
   title: string;
   /** 1-line lead под заголовком */
   subtitle?: string;
   /** Правый блок — primary action + ghost-actions (рендерится в сетке справа) */
   actions?: ReactNode;
-  /** Дополнительный slot правее actions — для mono-ссылок типа /staff/audit/events */
+  /** Дополнительный slot правее actions — для служебных ссылок типа /staff/audit/events */
   meta?: ReactNode;
 };
 

--- a/apps/master-web/src/components/ui/chart.tsx
+++ b/apps/master-web/src/components/ui/chart.tsx
@@ -251,7 +251,7 @@ function ChartTooltipContent({
                         </span>
                       </div>
                       {item.value != null && (
-                        <span className="font-mono font-medium text-foreground tabular-nums">
+                        <span className="font-medium text-foreground tabular-nums">
                           {typeof item.value === "number"
                             ? item.value.toLocaleString()
                             : String(item.value)}

--- a/apps/master-web/src/styles.css
+++ b/apps/master-web/src/styles.css
@@ -3,17 +3,14 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/ibm-plex-sans";
 @import "@fontsource-variable/source-serif-4";
-@import "@fontsource-variable/geist";
-@import "@fontsource-variable/fraunces";
-/* Канон Film Noir — packages/design-tokens (см. sync.mjs). Локальный :root ниже
-   пока переопределяет часть значений; расхождения снимаются в #39 и #40. */
+/* Канон Film Noir — packages/design-tokens (см. sync.mjs). */
 @import "./design-tokens.generated.css";
 
 @custom-variant dark (&:is(.dark *));
 
 :root {
   color-scheme: dark;
-  font-family: "IBM Plex Sans Variable", "Geist Variable", "Avenir Next", "Segoe UI", sans-serif;
+  font-family: var(--font-sans);
 
   /* ─── Film Noir palette ───
      Поверхности, текст, акцент-оксблад, бордеры и семантика приходят из
@@ -36,18 +33,11 @@
   --space-8: 32px;
   --space-10: 40px;
 
-  --font-serif: "Source Serif 4 Variable", "Source Serif 4", "Source Serif Pro", "Fraunces Variable", Georgia, serif;
-  --font-sans: "IBM Plex Sans Variable", "IBM Plex Sans", "Geist Variable", -apple-system, "Segoe UI", system-ui, sans-serif;
-  --font-mono: "IBM Plex Mono", "SF Mono", Menlo, monospace;
-
-  --fs-xs: 11px;
-  --fs-sm: 12px;
-  --fs-base: 13px;
-  --fs-md: 14px;
-  --fs-lg: 16px;
-  --fs-xl: 20px;
-  --fs-2xl: 28px;
-  --fs-3xl: 36px;
+  /* ─── Типографика ───
+     --font-serif, --font-sans и служебный --font-meta приходят из
+     packages/design-tokens/fonts.css. Monospace в системе нет: роль
+     служебного текста держит тот же sans (500 + трекинг + tabular-nums).
+     Шкала кеглей --fs-* — тоже канон. */
 
   /* ─── Локальные алиасы консоли ───
      shadcn-контракт (--background, --card, --primary, --chart-*, --ring, …)
@@ -366,7 +356,7 @@ p {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 8px;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-family: var(--font-meta);
   font-size: 10.5px;
   font-weight: 400;
   text-transform: uppercase;
@@ -408,7 +398,8 @@ p {
   border: 0;
   outline: 0;
   color: inherit;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 15px;
   letter-spacing: 0.01em;
 }
@@ -454,7 +445,8 @@ p {
   align-items: center;
   gap: 6px;
   margin-top: 8px;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 11px;
   color: var(--warning);
 }
@@ -507,7 +499,7 @@ p {
   border: 1px solid var(--accent);
   background: var(--accent);
   color: var(--accent-fg);
-  font-family: var(--font-sans, "Geist Variable", system-ui, sans-serif);
+  font-family: var(--font-sans);
   font-size: 16px;
   font-weight: 500;
   cursor: pointer;
@@ -535,7 +527,7 @@ p {
 
 .auth-screen__foot {
   text-align: center;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-family: var(--font-meta);
   font-size: 12px;
   letter-spacing: 0.04em;
   color: var(--text-muted);
@@ -723,7 +715,8 @@ p {
   border: 1px solid var(--border-default);
   border-bottom-width: 2px;
   color: var(--text-muted);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 10.5px;
   letter-spacing: 0.04em;
   line-height: 1;
@@ -1043,8 +1036,13 @@ p {
   letter-spacing: 0.2em;
 }
 
+/* Служебный слой: тот же sans, но 500 + трекинг + табличные цифры —
+   выравнивание чисел даёт фигура, а не моноширина (канон). */
 .mono {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  font-variant-numeric: tabular-nums;
 }
 
 .lead,
@@ -1692,7 +1690,8 @@ button.chip .chip__count {
   border-radius: 999px;
   background: var(--bg-elevated);
   color: var(--text-muted);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-variant-numeric: tabular-nums;
   font-size: 10.5px;
   line-height: 16px;
   font-weight: 500;
@@ -1792,7 +1791,8 @@ button.chip[data-active="true"] .chip__count {
 
 .tobacco-drawer__eyebrow {
   margin: 0;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -1937,7 +1937,8 @@ button.chip[data-active="true"] .chip__count {
 }
 
 .tobacco-drawer .inventory-editor-identity__col .section-h {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -2022,7 +2023,8 @@ button.chip[data-active="true"] .chip__count {
 
 .tobacco-detail-drawer__label {
   margin: 0;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -2057,7 +2059,8 @@ button.chip[data-active="true"] .chip__count {
 }
 
 .tobacco-detail-drawer__attributes dt {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2328,7 +2331,8 @@ input[type="checkbox"] {
   line-height: 1.3;
   letter-spacing: 0.04em;
   font-weight: 700;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-family: var(--font-meta);
+  font-variant-numeric: tabular-nums;
 }
 
 .automation-grid {
@@ -2559,7 +2563,9 @@ input[type="checkbox"] {
 
 .bot-status__heartbeat {
   margin: 2px 0 0;
-  font-family: ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
+  font-family: var(--font-meta);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
   font-size: 11px;
   color: var(--muted-foreground);
 }
@@ -2850,7 +2856,8 @@ input[type="checkbox"] {
 
 .rails-page__eyebrow {
   margin: 0;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -2998,7 +3005,8 @@ input[type="checkbox"] {
 }
 
 .rails-card__count {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
   font-size: var(--fs-xs);
   color: var(--text-muted);
@@ -3176,7 +3184,8 @@ input[type="checkbox"] {
 
 .rail-drawer__eyebrow {
   margin: 0;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -3277,7 +3286,7 @@ input[type="checkbox"] {
 }
 
 .rail-drawer__hint {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
   font-size: var(--fs-xs);
   color: var(--text-muted);
 }
@@ -3312,7 +3321,9 @@ input[type="checkbox"] {
 }
 
 .rail-drawer__mix-order {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
   font-size: var(--fs-xs);
   color: var(--text-muted);
   text-align: center;
@@ -3741,7 +3752,6 @@ input[type="checkbox"] {
 
 @theme inline {
   --font-heading: var(--font-sans);
-  --font-sans: 'IBM Plex Sans Variable', 'Geist Variable', sans-serif;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -3899,7 +3909,8 @@ input[type="checkbox"] {
   border: 0;
   outline: 0;
   color: var(--text-secondary);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-sm);
   cursor: pointer;
   padding-right: 4px;
@@ -3919,7 +3930,8 @@ input[type="checkbox"] {
 }
 
 .tobaccos-list__chip-filter-label {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 10.5px;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -3965,7 +3977,8 @@ input[type="checkbox"] {
   border-radius: 999px;
   background: var(--bg-elevated);
   color: var(--text-muted);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 10.5px;
   font-variant-numeric: tabular-nums;
 }
@@ -3993,7 +4006,7 @@ input[type="checkbox"] {
 .tobaccos-list .inventory-table thead th {
   background: var(--bg-raised);
   color: var(--text-muted);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
   font-size: 10.5px;
   font-weight: 500;
   text-transform: uppercase;
@@ -4038,7 +4051,8 @@ input[type="checkbox"] {
 
 .tobaccos-list .inventory-extra-filters__trigger {
   padding: 10px 12px;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -4129,7 +4143,8 @@ input[type="checkbox"] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 10.5px;
   color: var(--text-muted);
   background: var(--bg-elevated);
@@ -4169,7 +4184,8 @@ input[type="checkbox"] {
   border: 0;
   outline: 0;
   color: var(--text-secondary);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-sm);
   cursor: pointer;
   padding-right: 4px;
@@ -4189,7 +4205,8 @@ input[type="checkbox"] {
 }
 
 .mixes-list__profiles-label {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 10.5px;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -4219,7 +4236,7 @@ input[type="checkbox"] {
 .mixes-list .mixes-table thead th {
   background: var(--bg-raised);
   color: var(--text-muted);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
   font-size: 10.5px;
   font-weight: 500;
   text-transform: uppercase;
@@ -4267,7 +4284,8 @@ input[type="checkbox"] {
 
 .mixes-list .inventory-extra-filters__trigger {
   padding: 10px 12px;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -4325,7 +4343,8 @@ input[type="checkbox"] {
 
 .operator-dialog__eyebrow {
   margin: 0;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -4592,7 +4611,9 @@ input[type="checkbox"] {
 
 .access-audit__day {
   padding: 8px 18px;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
   font-size: 10.5px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -4789,7 +4810,7 @@ input[type="checkbox"] {
   border-radius: 6px;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid var(--accent-border);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
   font-size: 10px;
   font-weight: 700;
   color: var(--text-secondary);
@@ -4800,7 +4821,8 @@ input[type="checkbox"] {
 }
 
 .brand-chip__count {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-variant-numeric: tabular-nums;
   font-size: 11px;
   font-weight: 600;
   color: var(--text-muted);
@@ -5354,7 +5376,7 @@ input[type="checkbox"] {
   border-radius: 6px;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid var(--accent-border);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -5651,7 +5673,8 @@ input[type="checkbox"] {
 
 .inventory-editor-identity__col .section-h {
   margin: 0;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 10.5px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -5984,7 +6007,8 @@ input[type="checkbox"] {
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
   border-bottom-width: 2px;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 10.5px;
   color: var(--text-muted);
 }
@@ -6010,7 +6034,8 @@ input[type="checkbox"] {
 }
 
 .stat__label {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -6039,7 +6064,9 @@ input[type="checkbox"] {
 }
 
 .stat__value[data-tone="mono"] {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
   font-size: 22px;
   letter-spacing: 0.04em;
 }
@@ -6070,7 +6097,8 @@ input[type="checkbox"] {
 .list__head {
   height: 32px;
   background: var(--bg-raised);
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 10.5px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -6591,7 +6619,7 @@ input[type="checkbox"] {
 }
 
 .mixes-profile-filter__eyebrow {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(--font-meta);
   font-size: 0.66rem;
   font-weight: 700;
   letter-spacing: 0.12em;
@@ -6767,7 +6795,8 @@ input[type="checkbox"] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 0.66rem;
   color: var(--accent);
   background: rgba(255, 255, 255, 0.05);
@@ -7296,7 +7325,8 @@ input[type="checkbox"] {
 }
 
 .mix-builder__breadcrumb-meta {
-  font-family: ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 11px;
   color: var(--muted-foreground);
   white-space: nowrap;
@@ -7704,7 +7734,9 @@ input[type="checkbox"] {
 
 .mix-builder__library-count {
   margin: 0;
-  font-family: ui-monospace, monospace;
+  font-family: var(--font-meta);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
   font-size: 11px;
   color: var(--muted-foreground);
 }
@@ -7928,7 +7960,8 @@ input[type="checkbox"] {
   border: 1px solid var(--border);
   background: var(--background);
   color: var(--muted-foreground);
-  font-family: ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 12px;
   letter-spacing: 0.02em;
   cursor: pointer;
@@ -8035,7 +8068,7 @@ input[type="checkbox"] {
 }
 
 .mixes-cell__ratio {
-  font-family: ui-monospace, 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace !important;
+  font-family: var(--font-meta) !important;
   font-size: 11px !important;
   color: var(--muted-foreground) !important;
   letter-spacing: 0.04em;
@@ -8120,7 +8153,7 @@ input[type="checkbox"] {
   min-width: 26px;
   height: 22px;
   padding: 0 6px;
-  font-family: ui-monospace, 'JetBrains Mono', monospace;
+  font-family: var(--font-meta);
   font-size: 10px;
   letter-spacing: 0.08em;
   font-weight: 600;
@@ -8217,7 +8250,8 @@ input[type="checkbox"] {
 
 .master-page-header__eyebrow {
   margin: 0;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -8251,7 +8285,8 @@ input[type="checkbox"] {
 }
 
 .master-page-header__meta {
-  font-family: ui-monospace, 'JetBrains Mono', monospace;
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: 12px;
   color: var(--muted-foreground);
   letter-spacing: 0.04em;
@@ -8333,7 +8368,8 @@ input[type="checkbox"] {
 
 .dashboard-page__eyebrow {
   margin: 0;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-xs);
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -8371,7 +8407,9 @@ input[type="checkbox"] {
 }
 
 .dashboard-page__rank {
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
   font-size: 11px;
   color: var(--text-faint);
   letter-spacing: 0.04em;
@@ -8406,7 +8444,8 @@ input[type="checkbox"] {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-family: var(--font-mono);
+  font-family: var(--font-meta);
+  font-weight: 500;
   font-size: var(--fs-sm);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Связанный issue

Closes #40

## Bounded Context

Типографика консоли Мастера: служебный (meta) слой и шрифтовые семейства. Палитра, раскладка и тексты не тронуты.

## Touched Paths

- `apps/master-web/src/styles.css` — 50 мест служебного слоя, удаление локальных шрифтовых токенов и шкалы `--fs-*`
- `apps/master-web/src/components/ui/chart.tsx` — убран Tailwind-класс `font-mono` в тултипе
- `apps/master-web/src/components/shell/master-page-header.tsx` — комментарий описывал заголовок как «Fraunces огромный»
- `apps/master-web/package.json`, `package-lock.json` — удалены `@fontsource-variable/geist` и `@fontsource-variable/fraunces`

## Write Scope

**Monospace убран.** Было: `--font-mono: "IBM Plex Mono", "SF Mono", Menlo, monospace` плюс 15 захардкоженных стеков (`ui-monospace`, `SFMono-Regular`, `Consolas`, `Liberation Mono`, `JetBrains Mono`). IBM Plex Mono при этом нигде не подключался, так что служебный слой рендерился случайной системной моноширинкой — разной на macOS, Windows и Linux и разной в пределах одного экрана.

Стало: все 50 мест ссылаются на `--font-meta` из канона. Литералов `monospace` в `apps/master-web/src` не осталось; проверено и в живой странице — элементов с моноширинной гарнитурой ноль.

**Служебный слой получил полный рецепт, а не подмену семейства:**

- `font-weight: 500` — 37 блоков, у которых веса не было. Исключены `.rail-drawer__hint` и `.auth-screen__foot`: это проза в служебной гарнитуре, 500 сделал бы её тяжёлой.
- `font-variant-numeric: tabular-nums` — 9 блоков, где показываются числа: `.chip__count`, `.code-value`, `.bot-status__heartbeat`, `.rail-drawer__mix-order`, `.access-audit__day`, `.brand-chip__count`, `.stat__value[data-tone="mono"]`, `.mix-builder__library-count`, `.dashboard-page__rank`.
- Утилита `.mono` (логины, телефоны, коды, счётчики в Доступе) получила рецепт целиком: `--font-meta` + 500 + трекинг 0.1em + `tabular-nums`.

**Мёртвые семейства убраны.** Geist и Fraunces грузились и сидели в fallback-цепочках `--font-sans`, `--font-serif`, в `:root` и в `@theme inline` — при медленной загрузке основных гарнитур подставлялась чужая. Их в каноне нет.

```
dist до:    18 woff2, 504 КБ   (6 файлов — geist и fraunces)
dist после: 12 woff2, 360 КБ
```

Локальные `--font-serif`, `--font-sans`, `--font-mono` и шкала `--fs-xs…--fs-3xl` удалены как побайтные дубликаты канона; корневой `font-family` теперь `var(--font-sans)`.

**Вне scope:** `--r-*`, `--space-*` и `--row-h` в `:root` тоже дублируют канон, но это не типографика — не трогал.

## Checks Run

```bash
cd apps/master-web && npm ci                # ✓ lockfile без geist/fraunces ставится начисто
cd apps/master-web && npm test              # ✓ 44 теста
cd apps/master-web && npm run build         # ✓ 2.85s
node packages/design-tokens/sync.mjs --check # ✓ синхронны
```

Визуально: консоль поднята локально, снят экран входа. Служебные ярлыки (`ЛОГИН`, `ПАРОЛЬ`), значение логина и заголовок набраны как надо, ошибок в консоли браузера нет. В `getComputedStyle` живой страницы сверены `--font-meta`, `--font-sans`, `--font-serif`, `--fs-xs`, `--fs-3xl` и отсутствие моноширинных элементов.

**Чего не сделал:** экранов Дашборда, Табаков и Доступа — там, где служебного слоя больше всего, — глазами не видел: нужен backend, а локальный Postgres не поднимается (docker daemon не запущен). Числовые колонки этих экранов проверены по коду (каждому числовому блоку добавлен `tabular-nums`), функциональная проверка — за `atelier-smoke` на CI.

## Docs Updated

- [ ] `CLAUDE.md`
- [ ] `.claude/` (агенты или скиллы)
- [ ] `README.md`
- [x] `no docs changes required`

## Risks / Human Review Needed

1. **Риски.** Переход с моноширины на sans меняет ритм служебного слоя на каждом экране консоли — это цель, но экраны с плотными таблицами (Табаки, журнал Доступа) я вижу только через CI-smoke. Если где-то числа поедут, лечится точечным `tabular-nums`: рецепт уже централизован в `--font-meta` и `.mono`. Удаление двух npm-зависимостей проверено через `npm ci` начисто.
2. **Human Review не нужен** — process-, schema-, auth- и runtime-пути не затронуты.
3. **Категория:** ни одна из перечисленных.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
