### PR TITLE
chore(master-web): убрать мёртвый блок .dark из styles.css (#46)

### DIFF
--- a/apps/master-web/src/styles.css
+++ b/apps/master-web/src/styles.css
@@ -9,6 +9,10 @@
    пока переопределяет часть значений; расхождения снимаются в #39 и #40. */
 @import "./design-tokens.generated.css";
 
+/* Консоль тёмная всегда — через color-scheme и :root, без класса `dark`. Эта
+   директива держит tailwind-вариант `dark:` привязанным к классу вместо
+   дефолтного prefers-color-scheme: убрать её — и `dark:`-классы shadcn-кнопок
+   и бейджей оживут у пользователей с тёмной системной темой. */
 @custom-variant dark (&:is(.dark *));
 
 :root {
@@ -3782,35 +3786,6 @@ input[type="checkbox"] {
   --radius-4xl: calc(var(--radius) * 2.6);
 
   --spacing-row: var(--row-h);
-}
-
-.dark {
-  --background: var(--bg-base);
-  --foreground: var(--text-primary);
-  --card: var(--bg-raised);
-  --card-foreground: var(--text-primary);
-  --popover: var(--bg-elevated);
-  --popover-foreground: var(--text-primary);
-  --primary: var(--accent);
-  --primary-foreground: var(--accent-fg);
-  --secondary: var(--bg-raised);
-  --secondary-foreground: var(--text-primary);
-  --muted: var(--bg-raised);
-  --muted-foreground: var(--text-muted);
-  --accent: var(--bg-elevated);
-  --accent-foreground: var(--text-primary);
-  --destructive: var(--danger);
-  --border: var(--border-subtle);
-  --input: var(--input);
-  --ring: var(--accent-border);
-  --sidebar: var(--bg-raised);
-  --sidebar-foreground: var(--text-primary);
-  --sidebar-primary: var(--accent);
-  --sidebar-primary-foreground: var(--accent-fg);
-  --sidebar-accent: var(--bg-elevated);
-  --sidebar-accent-foreground: var(--text-primary);
-  --sidebar-border: var(--border-subtle);
-  --sidebar-ring: var(--accent-border);
 }
 
 .inventory-panel {


### PR DESCRIPTION
## Связанный issue

Closes #46

## Bounded Context

Уборка мёртвого блока `.dark { … }` в `apps/master-web/src/styles.css`. Класс `dark` в консоли нигде не навешивается: ни в `index.html`, ни в `main.tsx`, ни в `App.tsx`. Единственное упоминание во всём коде — `THEMES = { light: "", dark: ".dark" }` в boilerplate-компоненте `src/components/ui/chart.tsx`, который сам ни одним модулем не импортируется (чартов на Дашборде нет — `components/dashboard/dashboard-view.tsx` без recharts). Тёмность консоли даёт `color-scheme: dark` и `:root`.

Блок нёс две мины на случай, если класс когда-нибудь появится:

1. `--input: var(--input)` — самоссылка. Cyclic dependency делает переменную guaranteed-invalid внутри `.dark`, вместо наследования канонического `rgba(232, 230, 224, 0.07)` из `packages/design-tokens/colors.css`.
2. `--accent: var(--bg-elevated)` — shadcn-семантика «accent = hover surface» перебивала бренд-акцент оксблад `#B04A3E` серой поверхностью, ломая правило одного акцента Film Noir.

После #39 весь остаток блока — побайтовый дубль того, что уже отдают канон (`design-tokens.generated.css`) и локальный `:root` (`--accent-foreground`, `--sidebar-*`). Собственных значений в нём не осталось, поэтому блок удалён целиком, а не поправлен.

`@custom-variant dark (&:is(.dark *))` намеренно **оставлен** и снабжён комментарием: он держит tailwind-вариант `dark:` привязанным к классу вместо дефолтного `prefers-color-scheme`. Убрать его — и `dark:`-классы shadcn-кнопок и бейджей (`dark:border-input`, `dark:bg-input/30`, `dark:hover:bg-muted/50`, `dark:aria-invalid:*`) оживут у пользователей с тёмной системной темой и изменят вид.

## Touched Paths

- `apps/master-web/src/styles.css` (−28 / +4)

## Write Scope

Только `apps/master-web/src/styles.css`. Вне scope осознанно оставлены смежные находки, оформленные отдельно:

- мёртвый `src/components/ui/chart.tsx` и зависимость `recharts` — не трогались;
- `dark:`-классы в `src/components/ui/button.tsx` и `badge.tsx` — не трогались;
- `packages/design-tokens/**` и `design-tokens.generated.css` — не трогались, канон не менялся.

## Checks Run

```bash
cd apps/master-web && npm test    # 44 pass, 0 fail
cd apps/master-web && npm run build   # ✓ built
```

Дополнительно — доказательство, что правка no-op в рантайме: собран `dist/assets/index-*.css` из `origin/main` и из этой ветки, файлы разбиты на правила и сравнены. Из 1755 правил изменилось ровно одно — исчезнувшее `.dark{--background:…}`. Остальные 1754 совпадают побайтово, включая все `dark:`-утилиты `:is(.dark *)`.

Визуально: поднят Postgres + `apps/backend` (порт 3021) и dev-сервер `master-web`; экран входа рендерится штатно — тёмный фон, оксблад-кнопка, знак «А». Дашборд за формой входа не открывался: для этого нужен ввод пароля, который я не выполняю.

Smoke не запускался: изменение не затрагивает разметку, тексты, заголовки, ARIA-роли, табы и навигацию — только удаление неактивного CSS-правила. Assertion'ы в `tests/smoke/tests/*.spec.ts` поплыть не могут.

## Docs Updated

- [x] `no docs changes required`

## Risks / Human Review Needed

1. Остаточных рисков нет: удалённое правило было неактивно, идентичность собранного CSS проверена машинно.
2. `Human Review` не нужен.
3. Ни в одну из категорий PR не попадает: schema/auth/env/runtime — нет, public contract — нет, process/workflow/skills — нет, verification полная.
