### PR TITLE
feat(aroma-web): убрать локальные копии канона из :root

### DIFF
--- a/apps/aroma-web/src/lib/profile-color.ts
+++ b/apps/aroma-web/src/lib/profile-color.ts
@@ -1,19 +1,10 @@
-export const profileColor: Record<string, string> = {
-  citrus: "#e8b948",
-  berry: "#a23048",
-  floral_herbal: "#7a9560",
-  fresh: "#7fb5a3",
-  sweet: "#d98c5a",
-  spicy: "#c0492c",
-  dessert: "#b07747",
-  tobacco: "#7a5236",
-  minty: "#6ba88a",
-  fruity: "#dd8a4a",
-  perfume: "#c787a8",
-  sour: "#bcb04a",
-};
+import { PROFILE_COLORS, PROFILE_FALLBACK } from './profile-colors.generated';
 
-const FALLBACK = "#7a5236";
+/** Цвета вкусовых профилей — слой данных, не бренд (PRD §12).
+ *  Значения задаются в packages/design-tokens/profile-colors.css; сюда они
+ *  попадают генератором, потому что к цвету в halo-градиентах дописывается
+ *  альфа строкой и var() не подходит. */
+export const profileColor = PROFILE_COLORS;
 
 export const getProfileColor = (profileId: string | null | undefined): string =>
-  (profileId && profileColor[profileId]) || FALLBACK;
+  (profileId && profileColor[profileId]) || PROFILE_FALLBACK;

--- a/apps/aroma-web/src/lib/profile-colors.generated.ts
+++ b/apps/aroma-web/src/lib/profile-colors.generated.ts
@@ -1,0 +1,20 @@
+/* СГЕНЕРИРОВАННЫЙ ФАЙЛ — не редактировать.
+   Источник: packages/design-tokens/profile-colors.css
+   Перегенерация: node packages/design-tokens/sync.mjs */
+
+export const PROFILE_COLORS: Record<string, string> = {
+  citrus: '#e8b948',
+  berry: '#a23048',
+  floral_herbal: '#7a9560',
+  fresh: '#7fb5a3',
+  sweet: '#d98c5a',
+  spicy: '#c0492c',
+  dessert: '#b07747',
+  tobacco: '#7a5236',
+  minty: '#6ba88a',
+  fruity: '#dd8a4a',
+  perfume: '#c787a8',
+  sour: '#bcb04a',
+};
+
+export const PROFILE_FALLBACK = '#7a5236';

--- a/apps/aroma-web/src/styles.css
+++ b/apps/aroma-web/src/styles.css
@@ -35,51 +35,23 @@
 }
 
 :root {
+  /* ─── Палитра, шкалы и цвета профилей ───
+     Приходят из packages/design-tokens (design-tokens.generated.css выше):
+     поверхности, текст, акцент, бордеры, --profile-*, --composition-*.
+     Ниже — только то, что у гостя своё. */
+
   --radius: 0.95rem;
-  --background: #141417;
-  --foreground: #E8E6E0;
-  --card: #1C1C21;
-  --card-foreground: #E8E6E0;
-  --popover: #1C1C21;
-  --popover-foreground: #E8E6E0;
-  --primary: #B04A3E;
-  --primary-foreground: #F4EFEA;
+
+  /* Гостевые правки shadcn-контракта: у гостя контролы полупрозрачные,
+     а поповеры лежат на raised, а не на elevated, как в консоли. */
+  --popover: var(--bg-raised);
   --secondary: rgba(40, 40, 48, 0.62);
-  --secondary-foreground: #E8E6E0;
-  --muted: rgba(40, 40, 48, 0.66);
-  --muted-foreground: #B6B4AE;
-  --accent-ui: rgba(176, 74, 62, 0.14);
-  --accent-foreground: #F4EFEA;
-  --destructive: #CF4F44;
-  --border: rgba(150, 148, 142, 0.16);
+  --muted: var(--guest-control-bg);
+  --muted-foreground: var(--text-secondary);
+  --accent-ui: var(--accent-soft);
+  --accent-foreground: var(--accent-fg);
   --input: rgba(150, 148, 142, 0.22);
   --ring: rgba(176, 74, 62, 0.55);
-  --bg: #141417;
-  --surface: #1C1C21;
-  --surface-alt: #232329;
-  --surface-elevated: #2B2B32;
-  --accent: #B04A3E;
-  --accent-soft: #C25749;
-  --accent-deep: #7E342B;
-  --ember: #C25749;
-  --text-0: #E8E6E0;
-  --text-1: #B6B4AE;
-  --text-2: #8F8D87;
-  --line: rgba(150, 148, 142, 0.16);
-  --line-soft: rgba(150, 148, 142, 0.10);
-  --danger: #CF4F44;
-  --profile-citrus: #e8b948;
-  --profile-berry: #a23048;
-  --profile-floral-herbal: #7a9560;
-  --profile-fresh: #7fb5a3;
-  --profile-sweet: #d98c5a;
-  --profile-spicy: #c0492c;
-  --profile-dessert: #b07747;
-  --profile-tobacco: #7a5236;
-  --profile-minty: #6ba88a;
-  --profile-fruity: #dd8a4a;
-  --profile-perfume: #c787a8;
-  --profile-sour: #bcb04a;
   /* --font-display (Literata) и --font-body (Mulish) — из канона,
      packages/design-tokens/fonts.css. Файлы гарнитур подключены выше. */
   --safe-top: env(safe-area-inset-top, 0px);
@@ -136,7 +108,7 @@ button,
 button:focus-visible,
 input:focus-visible,
 select:focus-visible {
-  outline: 2px solid var(--accent-soft);
+  outline: 2px solid var(--accent-hover);
   outline-offset: 2px;
 }
 
@@ -284,7 +256,7 @@ select:focus-visible {
 .header-auth-btn {
   border: 1px solid var(--line);
   background: var(--secondary);
-  color: var(--accent-soft);
+  color: var(--accent-hover);
   border-radius: 999px;
   min-height: 40px;
   padding: 0 14px;
@@ -386,7 +358,7 @@ select:focus-visible {
 }
 
 .status.ok {
-  color: var(--accent-soft);
+  color: var(--accent-hover);
 }
 
 .ghost-button:disabled {
@@ -423,7 +395,7 @@ select:focus-visible {
 }
 
 .tab.active {
-  background: linear-gradient(180deg, var(--accent-soft) 0%, var(--accent) 100%);
+  background: linear-gradient(180deg, var(--accent-hover) 0%, var(--accent) 100%);
   color: var(--primary-foreground);
   border-color: rgba(176, 74, 62, 0.4);
   font-weight: 600;
@@ -576,11 +548,11 @@ select:focus-visible {
   text-align: center;
   text-transform: uppercase;
   outline: none;
-  caret-color: var(--accent-soft);
+  caret-color: var(--accent-hover);
 }
 
 .aroma-access-code-input:focus-visible {
-  border-bottom-color: var(--accent-soft);
+  border-bottom-color: var(--accent-hover);
 }
 
 .aroma-access-code-hint {
@@ -844,7 +816,7 @@ select:focus-visible {
 .aroma-profile-card-on {
   border-color: var(--primary);
   background: linear-gradient(180deg, rgba(176, 74, 62, 0.24) 0%, rgba(176, 74, 62, 0.14) 100%);
-  color: var(--accent-soft);
+  color: var(--accent-hover);
 }
 
 .aroma-profile-card-dot {
@@ -1038,7 +1010,7 @@ select:focus-visible {
 
 .aroma-recs-comp-share {
   font-size: 13px;
-  color: var(--accent-soft);
+  color: var(--accent-hover);
   font-variant-numeric: tabular-nums;
   font-weight: 500;
 }
@@ -1142,7 +1114,7 @@ select:focus-visible {
 }
 
 .aroma-catalog-search:focus-visible {
-  border-color: var(--accent-soft);
+  border-color: var(--accent-hover);
 }
 
 .aroma-catalog-icon-btn {
@@ -1216,7 +1188,7 @@ select:focus-visible {
 
 .aroma-catalog-sort-btn-on {
   border-color: var(--primary);
-  color: var(--accent-soft);
+  color: var(--accent-hover);
   background: linear-gradient(180deg, rgba(176, 74, 62, 0.24) 0%, rgba(176, 74, 62, 0.14) 100%);
 }
 
@@ -1563,7 +1535,7 @@ select:focus-visible {
 
 .aroma-mix-sheet-comp-share {
   font-size: 13px;
-  color: var(--accent-soft);
+  color: var(--accent-hover);
   font-variant-numeric: tabular-nums;
   font-weight: 500;
 }
@@ -1593,7 +1565,7 @@ select:focus-visible {
 .aroma-mix-sheet-star-on {
   border-color: var(--primary);
   background: linear-gradient(180deg, rgba(176, 74, 62, 0.24) 0%, rgba(176, 74, 62, 0.14) 100%);
-  color: var(--accent-soft);
+  color: var(--accent-hover);
 }
 
 .aroma-mix-sheet-actions {
@@ -1733,7 +1705,7 @@ select:focus-visible {
 .aroma-smoke-confirmation-comp-share {
   font-family: var(--font-display);
   font-size: 22px;
-  color: var(--accent-soft);
+  color: var(--accent-hover);
   font-variant-numeric: tabular-nums;
 }
 
@@ -1785,7 +1757,7 @@ select:focus-visible {
 .aroma-rail-code {
   border: 1px solid rgba(176, 74, 62, 0.20);
   background: var(--secondary);
-  color: var(--accent-soft);
+  color: var(--accent-hover);
   border-radius: 999px;
   height: 34px;
   padding: 0 14px;

--- a/packages/design-tokens/sync.mjs
+++ b/packages/design-tokens/sync.mjs
@@ -19,6 +19,11 @@ const HEADER = `/* СГЕНЕРИРОВАННЫЙ ФАЙЛ — не редакт
    Источник: packages/design-tokens/. Перегенерация: node packages/design-tokens/sync.mjs
    Правки здесь потеряются и уронят CI-проверку atelier-design-tokens. */\n`;
 
+const TS_HEADER = `/* СГЕНЕРИРОВАННЫЙ ФАЙЛ — не редактировать.
+   Источник: packages/design-tokens/profile-colors.css
+   Перегенерация: node packages/design-tokens/sync.mjs */
+`;
+
 /** Собирает index.css в один файл, разворачивая относительные @import. */
 function inline(entry) {
   const css = readFileSync(entry, 'utf8');
@@ -28,11 +33,38 @@ function inline(entry) {
   });
 }
 
+/** Цвета профилей нужны гостю ещё и как строки в JS: к ним дописывается альфа
+ *  (`${color}48` в halo-градиентах), поэтому var() там не подходит. Карта
+ *  генерируется из того же profile-colors.css, чтобы копия не жила своей жизнью. */
+function profileModule() {
+  const css = readFileSync(join(here, 'profile-colors.css'), 'utf8');
+  const entries = [...css.matchAll(/--profile-([a-z-]+):\s*(#[0-9a-f]{6});/g)]
+    .map(([, name, hex]) => [name.replace(/-/g, '_'), hex]);
+  const fallback = entries.find(([name]) => name === 'tobacco')?.[1];
+  if (entries.length !== 12 || !fallback) {
+    throw new Error(`profile-colors.css: ожидались 12 профилей и tobacco, найдено ${entries.length}`);
+  }
+  return [
+    TS_HEADER,
+    'export const PROFILE_COLORS: Record<string, string> = {',
+    ...entries.map(([name, hex]) => `  ${name}: '${hex}',`),
+    '};',
+    '',
+    `export const PROFILE_FALLBACK = '${fallback}';`,
+    '',
+  ].join('\n');
+}
+
 const bundle = HEADER + inline(join(here, 'index.css'));
 const check = process.argv.includes('--check');
 const drifted = [];
 
-for (const target of targets) {
+const artefacts = [
+  ...targets.map((target) => [target, bundle]),
+  ['apps/aroma-web/src/lib/profile-colors.generated.ts', profileModule()],
+];
+
+for (const [target, content] of artefacts) {
   const path = join(repoRoot, target);
   if (check) {
     let current = '';
@@ -42,9 +74,9 @@ for (const target of targets) {
       drifted.push(`${target} — отсутствует`);
       continue;
     }
-    if (current !== bundle) drifted.push(`${target} — разошёлся с packages/design-tokens/`);
+    if (current !== content) drifted.push(`${target} — разошёлся с packages/design-tokens/`);
   } else {
-    writeFileSync(path, bundle);
+    writeFileSync(path, content);
     console.log(`обновлён ${target}`);
   }
 }


### PR DESCRIPTION
## Связанный issue

Closes #54

## Bounded Context

Гостевая поверхность перестаёт держать собственные копии канона. Уборка дублей — значения не меняются, вид не меняется.

## Touched Paths

- `apps/aroma-web/src/styles.css` — `:root` с 47 строк до 17
- `apps/aroma-web/src/lib/profile-color.ts` — читает сгенерированную карту
- `apps/aroma-web/src/lib/profile-colors.generated.ts` — новый, генерируется
- `packages/design-tokens/sync.mjs` — умеет отдавать TS-карту профилей

## Write Scope

**Дубли убраны.** Из 47 строк `:root` тридцать три побайтно повторяли `packages/design-tokens`: поверхности, текст, акцент, бордеры, danger, shadcn-контракт и все двенадцать `--profile-*`. Осталось только своё:

```css
--radius: 0.95rem;                    /* у консоли 0.625rem */
--popover: var(--bg-raised);          /* у гостя поповер на raised, не на elevated */
--secondary: rgba(40, 40, 48, 0.62);  /* полупрозрачные контролы — в каноне нет такой альфы */
--muted: var(--guest-control-bg);
--muted-foreground: var(--text-secondary);
--accent-ui: var(--accent-soft);
--accent-foreground: var(--accent-fg);
--input: rgba(150, 148, 142, 0.22);
--ring: rgba(176, 74, 62, 0.55);      /* фокус-кольцо плотнее канонических 0.4 */
```

**Смыслы `--accent-soft` разведены** — это была та ловушка, из-за которой строку нельзя было просто удалить. Гость понимал токен как краску текста (`#C25749`) и использовал в 14 местах: `color`, `outline`, `caret-color`, `border-bottom-color`, стоп градиента. Канон зовёт так полупрозрачную подложку `rgba(176,74,62,.15)`. Все 14 переведены на `--accent-hover` — это ровно тот же `#C25749`; подложка осталась за `--accent-soft`, как в каноне. Мёртвый `--bg` удалён: в коде он не использовался ни разу.

**Цвета профилей были третьей копией.** Кроме канона и `:root` та же палитра лежала хекс-строками в `lib/profile-color.ts`. Перевести её на `var()` нельзя: в шести местах к цвету дописывается альфа строкой — `${haloColor}50`, `${color}aa`, `${profileColor}48` в halo-градиентах и глифах. `color-mix` решил бы это, но в гостевом контуре он пока не используется вообще, а на старых Android-вебвью невалидный цвет внутри градиента убивает всё объявление `background` — гость остался бы без подложки карточки. Поэтому `sync.mjs` теперь генерирует из `profile-colors.css` ещё и `profile-colors.generated.ts`: рантайм не меняется (те же хексы), источник один, дрейф ловит тот же `atelier-design-tokens`. Генератор падает, если в каноне не 12 профилей или нет `tobacco` для fallback.

**Вне scope:** значения палитры (это уборка, а не перекраска); контраст CTA — #52; консоль, где `--r-*`, `--space-*` и `--row-h` тоже дублируют канон.

## Checks Run

```bash
cd apps/aroma-web && npx tsc --noEmit    # ✓ без ошибок
cd apps/aroma-web && npm run build       # ✓ 1.73s
node packages/design-tokens/sync.mjs --check  # ✓ синхронны (три артефакта)
```

Визуально: гейт 18+ на 375×812 — знак, wordmark, фокус-кольцо на поле кода, активный CTA, юридический минимум выглядят как до правки. Ошибок в консоли нет.

Главная проверка — что ни один токен не остался без значения после удаления 33 строк. Собрал из всех CSSOM-правил живой страницы каждый использованный `var(--…)` и сверил с `getComputedStyle`: **119 токенов, все резолвятся**, кроме четырёх собственных `--default-*font-*-settings` Tailwind, которые пусты по своей природе.

**Чего не сделал:** экраны за гейтом — где как раз работают `--profile-*`, глифы и halo-градиенты — глазами не видел: нужен backend, локальный Postgres не поднимается (docker daemon не запущен). Значения профилей при этом не изменились ни на бит: генератор выдал те же хексы, что лежали в `profile-color.ts` руками (сверено по diff). Прогон `atelier-smoke` — на CI.

## Docs Updated

- [ ] `CLAUDE.md`
- [ ] `.claude/` (агенты или скиллы)
- [ ] `README.md`
- [x] `no docs changes required`

## Risks / Human Review Needed

1. **Риски.** Удаление 33 строк из `:root` — операция, где ошибка проявляется как пропавший цвет на экране, который я не открывал. Поэтому проверка шла не глазами, а перебором всех 119 токенов страницы. Второй момент: `--secondary` (альфа 0.62), `--input` (0.22) и `--ring` (0.55) остались литералами — в каноне нет токенов с такими значениями, а подгонять их под ближайшие канонические означало бы менять вид, чего этот PR делать не должен. Если решим, что гостевые контролы и фокус должны жить в каноне — это отдельный разговор о токенах, а не уборка.
2. **Human Review не нужен** — process-, schema-, auth- и runtime-пути не затронуты.
3. **Категория:** ни одна из перечисленных.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
