### PR TITLE
feat(design-tokens): углубить оксбладный градиент CTA и активного сегмента

### DIFF
--- a/apps/aroma-web/src/design-tokens.generated.css
+++ b/apps/aroma-web/src/design-tokens.generated.css
@@ -334,15 +334,19 @@
   --guest-chip-border-on: rgba(244, 239, 234, 0.34);
   --guest-dock-fade: linear-gradient(180deg, rgba(20, 20, 23, 0) 0%, rgba(20, 20, 23, 0.78) 30%, rgba(20, 20, 23, 0.95) 100%); /* @kind color */
 
-  /* Guest primary CTA — solid oxblood */
-  --cta-solid: linear-gradient(180deg, #c25749 0%, #b04a3e 100%); /* @kind color */
+  /* Guest primary CTA — solid oxblood.
+     Градиент идёт от --accent к --accent-deep, а не от --accent-hover к --accent:
+     кремовая надпись 13px/600 на светлой кромке #C25749 давала 3.87:1, ниже
+     AA 4.5:1 для обычного текста. На этой паре — 4.72:1 сверху и 7.62:1 снизу. */
+  --cta-solid: linear-gradient(180deg, #b04a3e 0%, #7e342b 100%); /* @kind color */
   --cta-solid-border: rgba(244, 239, 234, 0.22);
   --cta-solid-ink: #f4efea;
   --cta-solid-shadow: inset 0 1px 0 rgba(255, 243, 240, 0.18), 0 14px 26px rgba(126, 52, 43, 0.4);
   --cta-solid-disabled-bg: rgba(60, 28, 22, 0.6);
 
-  /* Segment nav (active) */
-  --segment-active-bg: linear-gradient(180deg, #c25749 0%, #b04a3e 100%);
+  /* Segment nav (active) — та же глубина, что у CTA: текст здесь 11px, то есть
+     требования к контрасту строже, а не мягче. */
+  --segment-active-bg: linear-gradient(180deg, #b04a3e 0%, #7e342b 100%);
   --segment-active-ink: #f4efea;
   --segment-active-border: rgba(244, 239, 234, 0.24);
   --segment-idle-bg: rgba(56, 24, 22, 0.54);

--- a/apps/master-web/src/design-tokens.generated.css
+++ b/apps/master-web/src/design-tokens.generated.css
@@ -334,15 +334,19 @@
   --guest-chip-border-on: rgba(244, 239, 234, 0.34);
   --guest-dock-fade: linear-gradient(180deg, rgba(20, 20, 23, 0) 0%, rgba(20, 20, 23, 0.78) 30%, rgba(20, 20, 23, 0.95) 100%); /* @kind color */
 
-  /* Guest primary CTA — solid oxblood */
-  --cta-solid: linear-gradient(180deg, #c25749 0%, #b04a3e 100%); /* @kind color */
+  /* Guest primary CTA — solid oxblood.
+     Градиент идёт от --accent к --accent-deep, а не от --accent-hover к --accent:
+     кремовая надпись 13px/600 на светлой кромке #C25749 давала 3.87:1, ниже
+     AA 4.5:1 для обычного текста. На этой паре — 4.72:1 сверху и 7.62:1 снизу. */
+  --cta-solid: linear-gradient(180deg, #b04a3e 0%, #7e342b 100%); /* @kind color */
   --cta-solid-border: rgba(244, 239, 234, 0.22);
   --cta-solid-ink: #f4efea;
   --cta-solid-shadow: inset 0 1px 0 rgba(255, 243, 240, 0.18), 0 14px 26px rgba(126, 52, 43, 0.4);
   --cta-solid-disabled-bg: rgba(60, 28, 22, 0.6);
 
-  /* Segment nav (active) */
-  --segment-active-bg: linear-gradient(180deg, #c25749 0%, #b04a3e 100%);
+  /* Segment nav (active) — та же глубина, что у CTA: текст здесь 11px, то есть
+     требования к контрасту строже, а не мягче. */
+  --segment-active-bg: linear-gradient(180deg, #b04a3e 0%, #7e342b 100%);
   --segment-active-ink: #f4efea;
   --segment-active-border: rgba(244, 239, 234, 0.24);
   --segment-idle-bg: rgba(56, 24, 22, 0.54);

--- a/packages/design-tokens/guest-surface.css
+++ b/packages/design-tokens/guest-surface.css
@@ -20,15 +20,19 @@
   --guest-chip-border-on: rgba(244, 239, 234, 0.34);
   --guest-dock-fade: linear-gradient(180deg, rgba(20, 20, 23, 0) 0%, rgba(20, 20, 23, 0.78) 30%, rgba(20, 20, 23, 0.95) 100%); /* @kind color */
 
-  /* Guest primary CTA — solid oxblood */
-  --cta-solid: linear-gradient(180deg, #c25749 0%, #b04a3e 100%); /* @kind color */
+  /* Guest primary CTA — solid oxblood.
+     Градиент идёт от --accent к --accent-deep, а не от --accent-hover к --accent:
+     кремовая надпись 13px/600 на светлой кромке #C25749 давала 3.87:1, ниже
+     AA 4.5:1 для обычного текста. На этой паре — 4.72:1 сверху и 7.62:1 снизу. */
+  --cta-solid: linear-gradient(180deg, #b04a3e 0%, #7e342b 100%); /* @kind color */
   --cta-solid-border: rgba(244, 239, 234, 0.22);
   --cta-solid-ink: #f4efea;
   --cta-solid-shadow: inset 0 1px 0 rgba(255, 243, 240, 0.18), 0 14px 26px rgba(126, 52, 43, 0.4);
   --cta-solid-disabled-bg: rgba(60, 28, 22, 0.6);
 
-  /* Segment nav (active) */
-  --segment-active-bg: linear-gradient(180deg, #c25749 0%, #b04a3e 100%);
+  /* Segment nav (active) — та же глубина, что у CTA: текст здесь 11px, то есть
+     требования к контрасту строже, а не мягче. */
+  --segment-active-bg: linear-gradient(180deg, #b04a3e 0%, #7e342b 100%);
   --segment-active-ink: #f4efea;
   --segment-active-border: rgba(244, 239, 234, 0.24);
   --segment-idle-bg: rgba(56, 24, 22, 0.54);


### PR DESCRIPTION
## Связанный issue

Closes #52

## Bounded Context

Контраст надписи на гостевых элементах с акцентной заливкой: главный CTA и активный сегмент навигации. Вариант B из issue, выбран владельцем.

## Touched Paths

- `packages/design-tokens/guest-surface.css` — `--cta-solid`, `--segment-active-bg`
- `apps/*/src/design-tokens.generated.css` — перегенерированы

## Write Scope

Градиент взят на две ступени глубже — `--accent` → `--accent-deep` вместо `--accent-hover` → `--accent`:

```css
--cta-solid:         linear-gradient(180deg, #b04a3e 0%, #7e342b 100%);
--segment-active-bg: linear-gradient(180deg, #b04a3e 0%, #7e342b 100%);
```

Контраст кремовой надписи `#F4EFEA`, посчитан в живой странице:

| точка | было | стало | AA 4.5:1 |
|---|---|---|---|
| верх кнопки | 3.87:1 | **4.72:1** | проходит |
| середина | 4.25:1 | **5.97:1** | проходит |
| низ кнопки | 4.72:1 | **7.62:1** | проходит |
| сегмент навигации, 11px | 3.87:1 | **4.72:1** | проходит |

Активный сегмент правился вместе с кнопкой намеренно: у него та же заливка, но текст 11px — требования там строже, а не мягче, и вариант C (крупная надпись) его бы не вылечил.

Правило одного акцента не нарушено — это тот же оксблад, только глубже. Ink, бордер, тень и disabled-состояние не тронуты.

**Вне scope:** пилюля рейтинга (`--rating-*` — 9:1, вопросов нет), чипы (кремовый на винной заливке — 8.76:1), консоль (палитра проверена в #39).

## Checks Run

```bash
cd apps/aroma-web && npm run build            # ✓ 1.87s
node packages/design-tokens/sync.mjs --check   # ✓ синхронны
```

Визуально: гейт 18+ на 375×812. Проверено ровно то, из-за чего вариант B мог не подойти — я сам это записал риском в issue: активная кнопка на новом градиенте и disabled-состояние `rgba(60,28,22,.6)` стоят рядом и различаются в 3.16:1, активная выключенной не читается. Заодно рядом показаны активный и неактивные сегменты — акцентный сегмент по-прежнему выделяется. Подпись disabled-состояния (`--text-2` на его фоне) держит 5.14:1.

**Чего не сделал:** экраны за гейтом, где живёт основная масса CTA («Покурить», «Показать подбор») и сама навигация, глазами не видел — нужен backend, локальный Postgres не поднимается (docker daemon не запущен). Значения при этом глобальные: и кнопка, и сегменты берут те же два токена, которые сверены в живой странице. Прогон `atelier-smoke` — на CI.

## Docs Updated

- [ ] `CLAUDE.md`
- [ ] `.claude/` (агенты или скиллы)
- [ ] `README.md`
- [x] `no docs changes required`

Обоснование выбранной глубины записано комментарием в самом `guest-surface.css` — рядом со значением, а не в отдельном документе.

## Risks / Human Review Needed

1. **Риски.** Кнопка стала темнее и тише — это заметно на каждом экране гостя, и на скриншоте видно, что она уже не «горит», а лежит в атмосфере зала. Если для главного CTA нужна прежняя яркость, компромисс придётся искать в другом месте: например, вернуть светлый градиент и поднять кегль надписи до large-text порога (вариант C из issue), но тогда сегменты навигации останутся ниже AA.
2. **Human Review не нужен** — process-, schema-, auth- и runtime-пути не затронуты.
3. **Категория:** ни одна из перечисленных.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
