### PR TITLE
feat(master-web): единая иконка спроса в карточке табака и пикере рейла

### DIFF
--- a/apps/master-web/src/components/inventory/inventory-view.tsx
+++ b/apps/master-web/src/components/inventory/inventory-view.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useRef, useState, type FormEvent, type KeyboardEvent } from 'react';
-import { ChevronDown, ChevronUp, Plus, Search } from 'lucide-react';
+import { ChevronDown, ChevronUp, Flame, Plus, Search, Star } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { FilterMultiSelect } from '@/components/ui/filter-multi-select';
@@ -894,7 +894,16 @@ export const InventoryView = ({
                     <strong>{mix.name}</strong>
                     <span>{formatMixCardStatus(mix)}</span>
                     <span className="cell-meta">
-                      Рейтинг {mix.avgRating.toFixed(1)} · выборов {formatMetricValue(mix.smokeCtaCount)}
+                      <span className="metric-inline" title="Популярность микса">
+                        <Flame size={11} aria-hidden="true" />
+                        <span className="sr-only">Выборов</span>
+                        {formatMetricValue(mix.smokeCtaCount)}
+                      </span>
+                      <span className="metric-inline" title="Средний рейтинг гостей">
+                        <Star size={11} aria-hidden="true" />
+                        <span className="sr-only">Рейтинг</span>
+                        {mix.avgRating.toFixed(1)}
+                      </span>
                     </span>
                   </button>
                 ))

--- a/apps/master-web/src/components/rails/rail-editor.tsx
+++ b/apps/master-web/src/components/rails/rail-editor.tsx
@@ -6,7 +6,7 @@ import {
   type FormEvent,
   type SetStateAction,
 } from 'react';
-import { Check, ChevronDown, ChevronUp, GripVertical, Plus, Search, X } from 'lucide-react';
+import { Check, ChevronDown, ChevronUp, Flame, GripVertical, Plus, Search, Star, X } from 'lucide-react';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import type { MixRecord, RailRecord } from '@/contracts';
 import { formatRailType } from '@/contracts';
@@ -179,7 +179,20 @@ export const RailEditor = ({
                       <div className="rail-drawer__picker-body">
                         <div className="rail-drawer__mix-name">{mix.name}</div>
                         <div className="rail-drawer__mix-meta">
-                          {mix.description || `Рейтинг ${mix.avgRating.toFixed(1)} · выборов ${mix.smokeCtaCount}`}
+                          {mix.description || (
+                            <span className="cell-meta">
+                              <span className="metric-inline" title="Популярность микса">
+                                <Flame size={11} aria-hidden="true" />
+                                <span className="sr-only">Выборов</span>
+                                {mix.smokeCtaCount}
+                              </span>
+                              <span className="metric-inline" title="Средний рейтинг гостей">
+                                <Star size={11} aria-hidden="true" />
+                                <span className="sr-only">Рейтинг</span>
+                                {mix.avgRating.toFixed(1)}
+                              </span>
+                            </span>
+                          )}
                         </div>
                       </div>
                       <span className="rail-drawer__picker-action" aria-hidden>

--- a/apps/master-web/src/styles.css
+++ b/apps/master-web/src/styles.css
@@ -6105,6 +6105,13 @@ input[type="checkbox"] {
   font-size: var(--fs-sm);
 }
 
+.metric-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
 .cell-truncate {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Closes #26

## Что изменено

`smokeCtaCount` выводился в трёх разных видах. Дашборд и каталог миксов уже показывают его иконкой `Flame`, а `inventory-view` и `rail-editor` — словом «выборов» внутри строки описания. Теперь все четыре поверхности читаются одинаково.

| Поверхность | Было | Стало |
|---|---|---|
| `inventory-view.tsx` (drawer табака → зависимые миксы) | `Рейтинг 4.8 · выборов 0` | `<Flame/> 0` `<Star/> 4.8` |
| `rail-editor.tsx` (пикер миксов, фолбэк описания) | `Рейтинг 4.6 · выборов 0` | `<Flame/> 0` `<Star/> 4.6` |

- иконки `size={11}`, `aria-hidden="true"` — как на эталонных поверхностях;
- порядок приведён к дашбордному: сначала спрос, затем рейтинг;
- отступ иконка↔значение — CSS `gap: 4px` в новом `.metric-inline` (рядом с `.cell-meta`), а не текстовый пробел; внешний отступ между метриками уже даёт `.cell-meta`.

### Решение по слову «выборов»

Issue просил зафиксировать явно. **Из видимого текста слово убрано**, но сохранено для скринридера через существующий `.sr-only`. Доступное имя от этого не ухудшилось, а стало точнее — проверено в браузере:

```
было:  «Цитрусовый караван Виден гостю Рейтинг 4.8 · выборов 0»
стало: «Цитрусовый караван Виден гостю Выборов 0 Рейтинг 4.8»
```

Плюс `title` на каждой метрике («Популярность микса» / «Средний рейтинг гостей») — те же формулировки, что в каталоге миксов.

## Проверки

- `cd apps/master-web && npm test` — 44 passed;
- `cd apps/master-web && npm run build` — зелёный;
- `cd tests/smoke && npm run smoke` — **4 passed**;
- визуально в браузере: drawer табака `Mint Veil` и пикер рейла «Свежая линия». Фолбэк в пикере проверен на миксе с временно очищенным описанием (описание возвращено), вёрстка внутри `nowrap`-строки не поехала — высота строки совпадает с соседними.

## Вне scope

`dashboard-view.tsx` и `mix-catalog-view.tsx` (уже приведены), смысл и расчёт метрики, сортировки по спросу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)