### PR TITLE
feat(smoke): развязать прогон от демо-фикстур seed

### DIFF
--- a/apps/master-web/src/components/inventory/inventory-view.tsx
+++ b/apps/master-web/src/components/inventory/inventory-view.tsx
@@ -1522,6 +1522,10 @@ export const InventoryView = ({
                   <tr
                     key={item.id}
                     data-active={isActive}
+                    // Якорь для smoke: имена табаков в реальном каталоге не
+                    // уникальны, а сортировка переставляет строки после
+                    // батч-операции (#27).
+                    data-tobacco-id={item.id}
                     className="inventory-table__row"
                     onClick={() => openEditEditor(item)}
                   >

--- a/apps/master-web/src/components/mixes/mix-catalog-view.tsx
+++ b/apps/master-web/src/components/mixes/mix-catalog-view.tsx
@@ -456,6 +456,8 @@ export const MixCatalogView = ({
                       key={mix.id}
                       data-blocked={!mix.available || undefined}
                       data-hidden={mix.available && !mix.guestVisible ? true : undefined}
+                      // Якорь для smoke — см. inventory-view (#27).
+                      data-mix-id={mix.id}
                       className="mixes-table__row"
                       onClick={() => onSelectMix(mix)}
                     >

--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -76,6 +76,27 @@ docker exec yummy-db-1 pg_dump -U atelier -d atelier -Fc --no-owner --no-privile
 docker cp yummy-db-1:/tmp/product.dump snapshots/atelier-product-data.dump
 ```
 
+### Что снэпшот не содержит
+
+В нём нет ни `StaffAccount`, ни `DailyAccessCode`, поэтому на свежевосстановленной
+базе нельзя ни войти в консоль Мастера, ни пройти гостевой вход. После restore
+нужно завести учётки и код:
+
+```bash
+cd apps/backend
+ATELIER_BOOTSTRAP_ADMIN_LOGIN=… ATELIER_BOOTSTRAP_ADMIN_PASSWORD=… npm run bootstrap:admin
+```
+
+daily code создаётся в консоли Мастера, раздел «Доступ».
+
+## Smoke и состояние базы
+
+`tests/smoke` проходит **и на демо-seed, и на продуктовом снэпшоте** — тесты не
+ссылаются на имена сущностей каталога и адресуют строки по `data-tobacco-id` /
+`data-mix-id`. Требования к состоянию базы, переменные окружения для нестандартных
+учёток и разбор проекта `master-seed-chromium` — в
+[`../../tests/smoke/README.md`](../../tests/smoke/README.md).
+
 ## Бэкапы и restore
 
 Полные дампы состояния (включая staff/auth и `atelier_test`) лежат вне репозитория

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -1,0 +1,90 @@
+# Smoke Арома Ателье
+
+Playwright-прогон по гостевому контуру (`aroma-web`) и консоли Мастера
+(`master-web`). Обязателен после правок разметки, текстов, ARIA и навигации —
+см. `CLAUDE.md` §3.
+
+```bash
+cd tests/smoke
+npm run smoke
+```
+
+## От какого состояния базы smoke обязан проходить
+
+Прогон **не зависит от демо-фикстур** `apps/backend/prisma/seed.ts`: имена
+табаков, миксов и prepared-рейлов берутся из самих данных, а строки таблиц
+адресуются по `data-tobacco-id` / `data-mix-id`. Требуется только:
+
+| Предпосылка | Зачем |
+|---|---|
+| учётка с ролью `admin` | инвентарь, каталог миксов, рейлы, раздел «Доступ» |
+| учётка с ролью `master` | проверка ограничений не-админа |
+| активный daily code | вход в гостевой контур |
+| ≥ 1 табак в каталоге | батч-флоу наличия |
+| ≥ 1 микс с составом | редактор микса и диалог удаления |
+| ≥ 1 guest-visible микс | статистический рейл «Больше всего выбирают» |
+
+Оба документированных способа наполнения базы этим условиям удовлетворяют:
+
+- **демо-seed** — `cd apps/backend && npm run prisma:seed` (учётки
+  `admin`/`admin` и `atelier`/`atelier`, daily code `1234`);
+- **продуктовый снапшот** — `snapshots/atelier-product-data.dump` (см.
+  `docs/data/README.md`). Снапшот содержит **только каталог** (`Tobacco`, `Mix`,
+  `MixComponent`, `Rail`, `RailMix`), поэтому учётки и код после восстановления
+  надо завести отдельно:
+
+  ```bash
+  cd apps/backend
+  ATELIER_BOOTSTRAP_ADMIN_LOGIN=… ATELIER_BOOTSTRAP_ADMIN_PASSWORD=… npm run bootstrap:admin
+  ```
+
+  daily code создаётся в консоли Мастера, раздел «Доступ».
+
+Прогон **неразрушающий**: наличие снимается и тут же возвращается, диалог
+удаления микса закрывается «Отменой», мусора в базе не остаётся.
+
+## Переменные окружения
+
+| Переменная | По умолчанию | Что задаёт |
+|---|---|---|
+| `ATELIER_AROMA_URL` | `http://127.0.0.1:5174` | адрес гостевого фронта |
+| `ATELIER_MASTER_URL` | `http://127.0.0.1:5176` | адрес консоли Мастера |
+| `ATELIER_SMOKE_ADMIN_LOGIN` / `…_PASSWORD` | `admin` / `admin` | учётка admin |
+| `ATELIER_SMOKE_OPERATOR_LOGIN` / `…_PASSWORD` | `atelier` / `atelier` | учётка master |
+| `ATELIER_SMOKE_ACCESS_CODE` | `1234` | daily code гостя |
+
+Пример прогона на базе из снапшота:
+
+```bash
+ATELIER_SMOKE_ADMIN_LOGIN=snapadmin ATELIER_SMOKE_ADMIN_PASSWORD=… \
+ATELIER_SMOKE_OPERATOR_LOGIN=snapmaster ATELIER_SMOKE_OPERATOR_PASSWORD=… \
+ATELIER_SMOKE_ACCESS_CODE=9876 npm run smoke
+```
+
+## Проекты
+
+| Проект | Файл | Предпосылка |
+|---|---|---|
+| `aroma-chromium` | `aroma-smoke.spec.ts` | любая наполненная база |
+| `master-chromium` | `master-smoke.spec.ts` | любая наполненная база |
+| `master-seed-chromium` | `master-seed.spec.ts` | **только демо-seed** |
+
+`master-seed-chromium` держит сценарии, которым нужны именно известные связи
+демо-фикстур (микс «Цитрусовый караван» в рейле «Свежая линия», его состав из
+двух конкретных табаков). Предпосылка проверяется в самом тесте: если фикстур
+нет, сценарий помечается `skipped` с внятной причиной, а не падает как
+UI-регрессия. Поэтому `npm run smoke` зелёный на обоих состояниях базы:
+
+- на демо-seed — 6 passed;
+- на продуктовом снапшоте — 4 passed, 2 skipped.
+
+## Что делать, когда smoke красный
+
+1. Проверить, что подняты `apps/backend` (`:3021`), `apps/aroma-web` (`:5174`) и
+   `apps/master-web` (`:5176`), и что фронты смотрят на живой API — у гостевого
+   контура адрес переопределяется в gitignored `apps/aroma-web/.env.local`
+   (см. его README).
+2. Посмотреть артефакты: `output/playwright/atelier-quality/` — скриншот, видео,
+   trace и `error-context.md` со снимком страницы.
+3. Не мерджить «оранжевый» smoke со списком «починим потом» — drift лечится в
+   том же PR, что его породил (`CLAUDE.md` §3).

--- a/tests/smoke/playwright.config.ts
+++ b/tests/smoke/playwright.config.ts
@@ -34,5 +34,16 @@ export default defineConfig({
         baseURL: masterBaseUrl,
       },
     },
+    // Сценарии, которым нужны именно демо-фикстуры seed. Вынесены в отдельный
+    // проект, чтобы общий прогон оставался зелёным и на продуктовом снапшоте:
+    // при отсутствии фикстур тесты помечают себя skipped (#27).
+    {
+      name: 'master-seed-chromium',
+      testMatch: /.*master-seed\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: masterBaseUrl,
+      },
+    },
   ],
 });

--- a/tests/smoke/tests/aroma-smoke.spec.ts
+++ b/tests/smoke/tests/aroma-smoke.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
+import { guestAccessCode } from './helpers';
 
 test('Aroma guest flow opens after daily code and exposes showcase/catalog without login', async ({ page }) => {
   await page.goto('/');
 
   await expect(page.getByText('Код мастера')).toBeVisible();
-  await page.getByLabel('Код мастера').fill('1234');
+  await page.getByLabel('Код мастера').fill(guestAccessCode);
   await page.getByRole('checkbox').click();
   await page.getByRole('button', { name: 'Войти в Ателье' }).click();
 

--- a/tests/smoke/tests/helpers.ts
+++ b/tests/smoke/tests/helpers.ts
@@ -1,0 +1,131 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+// Учётки и daily code, под которыми ходит smoke. Дефолты — из демо-seed
+// (`apps/backend/prisma/seed.ts`), но на базе, налитой продуктовым снапшотом,
+// логины и код другие: снапшот содержит только каталог (Tobacco, Mix,
+// MixComponent, Rail, RailMix), а учётки заводит `npm run bootstrap:admin`.
+// Поэтому значения переопределяются через окружение (#27).
+
+export const adminCredentials = {
+  login: process.env.ATELIER_SMOKE_ADMIN_LOGIN ?? 'admin',
+  password: process.env.ATELIER_SMOKE_ADMIN_PASSWORD ?? 'admin',
+};
+
+export const operatorCredentials = {
+  login: process.env.ATELIER_SMOKE_OPERATOR_LOGIN ?? 'atelier',
+  password: process.env.ATELIER_SMOKE_OPERATOR_PASSWORD ?? 'atelier',
+};
+
+export const guestAccessCode = process.env.ATELIER_SMOKE_ACCESS_CODE ?? '1234';
+
+export const signIn = async (login: string, password: string, page: Page) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Войти в смену' })).toBeVisible();
+  // exact-match: иначе getByLabel('Пароль') резолвится в 2 элемента —
+  // сам input и кнопку-«глаз» с aria-label «Показать пароль» (strict mode).
+  await page.getByLabel('Логин', { exact: true }).fill(login);
+  await page.getByLabel('Пароль', { exact: true }).fill(password);
+  await page.getByRole('button', { name: 'Войти' }).click();
+  // h1 после логина = title из MasterPageHeader (default `dashboard` →
+  // «Дашборд смены»). Route-шапка `.master-stage__header` удалена в
+  // chore/master-stage-header-cleanup — единственный h1 живёт внутри
+  // MasterPageHeader каждого workspace-view (см. CLAUDE.md §3, smoke gate
+  // после правок фронта).
+  await expect(
+    page.getByRole('heading', { name: 'Дашборд смены', level: 1 }),
+  ).toBeVisible();
+  await expect(page.getByRole('tablist', { name: 'Рабочие разделы Мастера' })).toBeVisible();
+};
+
+export const getWorkspaceTab = (page: Page, label: string) =>
+  page
+    .getByRole('tab')
+    .filter({
+      has: page.getByText(label, { exact: true }),
+    });
+
+export const openWorkspace = async (page: Page, label: string) => {
+  const tab = getWorkspaceTab(page, label);
+  await tab.click();
+  await expect(tab).toHaveAttribute('aria-selected', 'true');
+};
+
+export const getInventoryRow = (page: Page, name: string): Locator =>
+  page.locator('tbody tr').filter({
+    has: page.getByRole('cell', { name }),
+  });
+
+// Каталог миксов = таблица с богатой row-композицией (МИКС / СОСТАВ /
+// ПРОФИЛЬ / СТАТУС / МЕТРИКИ / ДЕЙСТВИЯ) — соответствует mockups.html.
+// PR #63 раньше попытался card-grid; PR-B вернул table back.
+export const getMixRow = (page: Page, name: string): Locator =>
+  page.locator('table.mixes-table tbody tr').filter({
+    has: page.getByText(name, { exact: true }),
+  });
+
+// Сущности каталога smoke берёт из самих данных, а не из демо-seed: иначе
+// прогон красный на любой базе, налитой продуктовым снапшотом (#27).
+//
+// Опора именно на позицию строки, а не на имя: в реальном каталоге имена не
+// уникальны — в снапшоте htreviews есть «1001 Nights» и от Layalina, и от
+// Afzal, и локатор по имени падает на strict mode violation. Сортировка при
+// этом переключается на алфавитную: дефолтная «сначала по наличию» переставит
+// строку сразу после батч-операции, и локатор `.first()` укажет уже на другую.
+export const pinFirstInventoryRow = async (
+  page: Page,
+): Promise<{ row: Locator; name: string }> => {
+  const first = page.locator('tbody tr[data-tobacco-id]').first();
+  const checkbox = first.getByRole('checkbox');
+  await expect(checkbox).toBeVisible();
+  const id = await first.getAttribute('data-tobacco-id');
+  const label = await checkbox.getAttribute('aria-label');
+  expect(label, 'у чекбокса строки инвентаря есть aria-label «Выбрать …»').toMatch(/^Выбрать /);
+
+  return {
+    // Батч-операция снимает наличие, а дефолтная сортировка «сначала по
+    // наличию» тут же переставляет строку — на каталоге из 11 505 позиций она
+    // уезжает вообще на другую страницу. Поэтому строка адресуется по id, а не
+    // по позиции или имени (имена в каталоге htreviews не уникальны).
+    row: page.locator(`tbody tr[data-tobacco-id="${id}"]`),
+    name: label!.replace(/^Выбрать /, ''),
+  };
+};
+
+export const stockFilterChip = (page: Page, label: string): Locator =>
+  page.getByRole('button', { name: `Фильтр: ${label}` });
+
+// Поле поиска в сценарии не используется намеренно: дебаунс отправляет снимок
+// фильтров, взятый до ввода, и запоздавший ответ возвращает `stock` к прежнему
+// значению (App.tsx, onInventorySearchChange собирает nextFilters из
+// inventoryFilters в замыкании). Это дефект приложения, а не теста, — заведён
+// отдельной задачей; smoke просто не опирается на связку «поиск + фильтр».
+export const applyStockFilter = async (page: Page, label: string) => {
+  const chip = stockFilterChip(page, label);
+  await chip.click();
+  await expect(chip).toHaveAttribute('aria-pressed', 'true');
+  // Ответ на перезапрос списка сбрасывает выделение строк, поэтому отмечать
+  // чекбоксы можно только после того, как список догрузился.
+  await page.waitForLoadState('networkidle');
+};
+
+// Счётчик внутри чипа наличия — самый устойчивый сигнал батч-операции: он не
+// зависит ни от сортировки, ни от пагинации, ни от размера каталога.
+export const readStockFilterCount = async (page: Page, label: string): Promise<number> => {
+  const raw = await stockFilterChip(page, label).locator('.filter-chip__count').innerText();
+  return Number(raw.replace(/\s/g, ''));
+};
+
+export const pinFirstMixRow = async (page: Page): Promise<Locator> => {
+  const first = page.locator('table.mixes-table tbody tr[data-mix-id]').first();
+  await expect(first).toBeVisible();
+  const id = await first.getAttribute('data-mix-id');
+  return page.locator(`table.mixes-table tbody tr[data-mix-id="${id}"]`);
+};
+
+// Имя нужно только там, где оно попадает в текст диалога или в aria-label
+// кнопки строки.
+export const readMixName = async (row: Locator): Promise<string> => {
+  const title = row.locator('.mixes-cell__title strong');
+  await expect(title).toBeVisible();
+  return (await title.innerText()).trim();
+};

--- a/tests/smoke/tests/master-seed.spec.ts
+++ b/tests/smoke/tests/master-seed.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+import { adminCredentials, getMixRow, openWorkspace, signIn } from './helpers';
+
+// Проект `master-seed-chromium`: сценарии, которым нужны именно демо-фикстуры
+// `apps/backend/prisma/seed.ts`. Продуктовый снапшот таких связей не гарантирует,
+// поэтому предпосылка проверяется явно и при её отсутствии тест помечается
+// skipped с внятной причиной, а не падает как UI-регрессия (#27).
+
+const demoMixName = 'Цитрусовый караван';
+const demoRailName = 'Свежая линия';
+
+test('Deleting a seeded mix warns about rails it belongs to', async ({ page }) => {
+  await signIn(adminCredentials.login, adminCredentials.password, page);
+
+  await openWorkspace(page, 'Миксы');
+  // Ждём отрисовки каталога: иначе проверка предпосылки поймает пустую таблицу
+  // и пропустит сценарий на базе, где фикстуры на самом деле есть.
+  await expect(page.locator('table.mixes-table tbody tr').first()).toBeVisible();
+  const mixRow = getMixRow(page, demoMixName);
+  test.skip(
+    (await mixRow.count()) === 0,
+    `База налита не демо-фикстурами: микса «${demoMixName}» нет. Сценарий требует apps/backend/prisma/seed.ts (npm run prisma:seed).`,
+  );
+
+  // «Цитрусовый караван» входит в prepared-рейл «Свежая линия», поэтому
+  // предупреждение перечисляет рейлы. Не подтверждаем удаление — прогон
+  // остаётся неразрушающим.
+  await mixRow.getByRole('button', { name: `Удалить ${demoMixName}` }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: `Удалить микс «${demoMixName}»?` }),
+  ).toBeVisible();
+  await expect(page.getByText(demoRailName)).toBeVisible();
+  await page.getByRole('button', { name: 'Отмена' }).click();
+  await expect(page.getByRole('dialog')).toBeHidden();
+  await expect(mixRow).toBeVisible();
+});
+
+test('Seeded mix editor shows the expected component composition', async ({ page }) => {
+  await signIn(adminCredentials.login, adminCredentials.password, page);
+
+  await openWorkspace(page, 'Миксы');
+  // Ждём отрисовки каталога: иначе проверка предпосылки поймает пустую таблицу
+  // и пропустит сценарий на базе, где фикстуры на самом деле есть.
+  await expect(page.locator('table.mixes-table tbody tr').first()).toBeVisible();
+  const mixRow = getMixRow(page, demoMixName);
+  test.skip(
+    (await mixRow.count()) === 0,
+    `База налита не демо-фикстурами: микса «${demoMixName}» нет. Сценарий требует apps/backend/prisma/seed.ts (npm run prisma:seed).`,
+  );
+
+  await mixRow.click();
+  await expect(page.getByRole('heading', { name: demoMixName })).toBeVisible();
+  await expect(page.getByText('сумма = 100%')).toBeVisible();
+  await expect(page.locator('.mix-builder__component').nth(0)).toContainText('Citrus Breeze');
+  await expect(page.locator('.mix-builder__component').nth(1)).toContainText('Mint Veil');
+
+  await page.getByRole('button', { name: 'Отмена' }).click();
+  await expect(page.locator('.mix-builder')).toBeHidden();
+});

--- a/tests/smoke/tests/master-smoke.spec.ts
+++ b/tests/smoke/tests/master-smoke.spec.ts
@@ -1,52 +1,19 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
-
-const signIn = async (login: string, password: string, page: Page) => {
-  await page.goto('/');
-  await expect(page.getByRole('heading', { name: 'Войти в смену' })).toBeVisible();
-  // exact-match: иначе getByLabel('Пароль') резолвится в 2 элемента —
-  // сам input и кнопку-«глаз» с aria-label «Показать пароль» (strict mode).
-  await page.getByLabel('Логин', { exact: true }).fill(login);
-  await page.getByLabel('Пароль', { exact: true }).fill(password);
-  await page.getByRole('button', { name: 'Войти' }).click();
-  // h1 после логина = title из MasterPageHeader (default `dashboard` →
-  // «Дашборд смены»). Route-шапка `.master-stage__header` удалена в
-  // chore/master-stage-header-cleanup — единственный h1 живёт внутри
-  // MasterPageHeader каждого workspace-view (см. CLAUDE.md §3, smoke gate
-  // после правок фронта).
-  await expect(
-    page.getByRole('heading', { name: 'Дашборд смены', level: 1 }),
-  ).toBeVisible();
-  await expect(page.getByRole('tablist', { name: 'Рабочие разделы Мастера' })).toBeVisible();
-};
-
-const getWorkspaceTab = (page: Page, label: string) =>
-  page
-    .getByRole('tab')
-    .filter({
-      has: page.getByText(label, { exact: true }),
-    });
-
-const openWorkspace = async (page: Page, label: string) => {
-  const tab = getWorkspaceTab(page, label);
-  await tab.click();
-  await expect(tab).toHaveAttribute('aria-selected', 'true');
-};
-
-const getInventoryRow = (page: Page, name: string): Locator =>
-  page.locator('tbody tr').filter({
-    has: page.getByRole('cell', { name }),
-  });
-
-// Каталог миксов = таблица с богатой row-композицией (МИКС / СОСТАВ /
-// ПРОФИЛЬ / СТАТУС / МЕТРИКИ / ДЕЙСТВИЯ) — соответствует mockups.html.
-// PR #63 раньше попытался card-grid; PR-B вернул table back.
-const getMixRow = (page: Page, name: string): Locator =>
-  page.locator('table.mixes-table tbody tr').filter({
-    has: page.getByText(name, { exact: true }),
-  });
+import { expect, test } from '@playwright/test';
+import {
+  adminCredentials,
+  applyStockFilter,
+  getWorkspaceTab,
+  openWorkspace,
+  operatorCredentials,
+  pinFirstInventoryRow,
+  pinFirstMixRow,
+  readStockFilterCount,
+  readMixName,
+  signIn,
+} from './helpers';
 
 test('Master workspace tabs support keyboard navigation for critical admin sections', async ({ page }) => {
-  await signIn('admin', 'admin', page);
+  await signIn(adminCredentials.login, adminCredentials.password, page);
 
   await expect(page.getByRole('tablist', { name: 'Рабочие разделы Мастера' })).toBeVisible();
   await expect(getWorkspaceTab(page, 'Дашборд')).toHaveAttribute('aria-selected', 'true');
@@ -75,20 +42,37 @@ test('Master workspace tabs support keyboard navigation for critical admin secti
 });
 
 test('Master admin smoke covers inventory batch flow, mixes editor, rails read-only mode and access observability', async ({ page }) => {
-  await signIn('admin', 'admin', page);
+  await signIn(adminCredentials.login, adminCredentials.password, page);
 
   await openWorkspace(page, 'Табаки');
-  const mintVeilRow = getInventoryRow(page, 'Mint Veil');
-  await expect(mintVeilRow).toBeVisible();
+  const { row: tobaccoRow } = await pinFirstInventoryRow(page);
 
-  await mintVeilRow.getByRole('checkbox', { name: 'Выбрать Mint Veil' }).check();
+  const outOfStockBefore = await readStockFilterCount(page, 'Нет наличия');
+
+  await tobaccoRow.getByRole('checkbox').check();
   await expect(page.getByText('Выбрано позиций: 1')).toBeVisible();
+  // Батч-флоу неразрушающий: наличие снимается и тут же возвращается, поэтому
+  // прогон не меняет состояние базы — важно и для демо-seed, и для снапшота.
   await page.getByRole('button', { name: 'Убрать из наличия' }).click();
-  await expect(mintVeilRow.getByText('Нет наличия')).toBeVisible();
+  // Результат читается по счётчику чипа, а не по статусу в исходной строке:
+  // при сортировке по умолчанию («сначала по наличию») строка уезжает в конец
+  // списка, а на каталоге из 11 505 позиций — вообще на другую страницу.
+  await expect
+    .poll(() => readStockFilterCount(page, 'Нет наличия'))
+    .toBe(outOfStockBefore + 1);
 
-  await mintVeilRow.getByRole('checkbox', { name: 'Выбрать Mint Veil' }).check();
+  // Возврат — из отфильтрованного списка снятых, где строка гарантированно
+  // видна независимо от размера каталога.
+  await applyStockFilter(page, 'Нет наличия');
+  await expect(tobaccoRow).toBeVisible();
+  await tobaccoRow.getByRole('checkbox').check();
+  await expect(page.getByText('Выбрано позиций: 1')).toBeVisible();
   await page.getByRole('button', { name: 'Вернуть в наличие' }).click();
-  await expect(mintVeilRow.getByText('В наличии')).toBeVisible();
+  await expect
+    .poll(() => readStockFilterCount(page, 'Нет наличия'))
+    .toBe(outOfStockBefore);
+
+  await applyStockFilter(page, 'Все');
 
   // Фильтр «Архив» (issue #129): по умолчанию архивные скрыты, чип не нажат.
   // Переключаем фильтр и убеждаемся, что он становится активным, затем
@@ -101,19 +85,21 @@ test('Master admin smoke covers inventory batch flow, mixes editor, rails read-o
   await expect(archiveFilter).toHaveAttribute('aria-pressed', 'false');
 
   await openWorkspace(page, 'Миксы');
-  const citrusMixRow = getMixRow(page, 'Цитрусовый караван');
-  await expect(citrusMixRow).toBeVisible();
+  const mixRow = await pinFirstMixRow(page);
+  const mixName = await readMixName(mixRow);
   // Row-click открывает редактор (drawer-pattern из mockup'а Master).
   // Прежняя кнопка «Открыть» в actions-cell заменена на icon edit/copy/hide;
   // edit-icon скрыт до hover, поэтому кликаем по самой строке.
-  await citrusMixRow.click();
+  await mixRow.click();
   // MixBuilder открывается full-page (3-колоночный layout) — Sheet удалён
   // в шаге 5 рефактора по design/design_handoff_master_refactor §Микс —
   // конструктор. Имя микса — `<h2>` в sticky-breadcrumb сверху-слева.
-  await expect(page.getByRole('heading', { name: 'Цитрусовый караван' })).toBeVisible();
-  await expect(page.getByText('сумма = 100%')).toBeVisible();
-  await expect(page.locator('.mix-builder__component').nth(0)).toContainText('Citrus Breeze');
-  await expect(page.locator('.mix-builder__component').nth(1)).toContainText('Mint Veil');
+  await expect(page.getByRole('heading', { name: mixName })).toBeVisible();
+  // Тег «сумма = 100%» показывается только при totalPercent === 100, то есть
+  // зависит от долей конкретного микса. Проверяем сам breadcrumb и наличие
+  // состава — они есть у любого микса.
+  await expect(page.locator('.mix-builder__breadcrumb')).toBeVisible();
+  await expect(page.locator('.mix-builder__component').first()).toBeVisible();
 
   // Возвращаемся в каталог через кнопку «Отмена» в шапке MixBuilder —
   // полноэкранный layout не оверлей, но всё равно прячем его перед
@@ -121,22 +107,23 @@ test('Master admin smoke covers inventory batch flow, mixes editor, rails read-o
   await page.getByRole('button', { name: 'Отмена' }).click();
   await expect(page.locator('.mix-builder')).toBeHidden();
 
-  // Удаление микса = подтверждающий диалог, текст которого зависит от
-  // участия микса в рейлах. «Цитрусовый караван» входит в prepared-рейл
-  // «Свежая линия», поэтому предупреждение перечисляет рейлы. Не
-  // подтверждаем (Отмена) — smoke остаётся неразрушающим для остальных
-  // assertion'ов на seed-данных.
-  await citrusMixRow.getByRole('button', { name: 'Удалить Цитрусовый караван' }).click();
+  // Удаление микса = подтверждающий диалог. Не подтверждаем (Отмена) — smoke
+  // остаётся неразрушающим. Перечисление рейлов внутри диалога зависит от
+  // того, входит ли микс в рейл, поэтому живёт в master-seed.spec.ts.
+  await mixRow.getByRole('button', { name: `Удалить ${mixName}` }).click();
   await expect(page.getByRole('dialog')).toBeVisible();
   await expect(
-    page.getByRole('heading', { name: 'Удалить микс «Цитрусовый караван»?' }),
+    page.getByRole('heading', { name: `Удалить микс «${mixName}»?` }),
   ).toBeVisible();
-  await expect(page.getByText('Свежая линия')).toBeVisible();
   await page.getByRole('button', { name: 'Отмена' }).click();
   await expect(page.getByRole('dialog')).toBeHidden();
-  await expect(citrusMixRow).toBeVisible();
+  await expect(mixRow).toBeVisible();
 
   await openWorkspace(page, 'Рейлы');
+  // «Больше всего выбирают» — системный statistical-рейл: backend синтезирует
+  // его на лету (`buildTopRail` в apps/backend/src/state.ts), строкой в базе
+  // он не лежит. Имя продуктовое, а не фикстурное, поэтому опора на него не
+  // возвращает зависимость от seed.
   const statisticalRail = page.locator('article').filter({
     has: page.getByRole('heading', { name: 'Больше всего выбирают' }),
   });
@@ -166,7 +153,7 @@ test('Master admin smoke covers inventory batch flow, mixes editor, rails read-o
 });
 
 test('Master non-admin role keeps admin-only surfaces restricted while preserving access context', async ({ page }) => {
-  await signIn('atelier', 'atelier', page);
+  await signIn(operatorCredentials.login, operatorCredentials.password, page);
 
   await openWorkspace(page, 'Доступ');
   await expect(page.getByRole('heading', { name: 'Доступ и персонал', level: 1 })).toBeVisible();


### PR DESCRIPTION
Closes #27

⚠️ **Требует human review** — `tests/smoke/**` входит в process-governance пути `.github/REVIEW_POLICY.md`. Не мержу сам.

## Проблема

`master-smoke.spec.ts:82` искал строку таблицы по имени табака `Mint Veil` из `prisma/seed.ts`. На базе, налитой продуктовым снапшотом — то есть по документированному в README пути «быстрое развёртывание из снэпшота», — такого табака нет, и smoke был красным независимо от корректности кода.

## Что сделано

**Тесты больше не ссылаются на имена сущностей каталога.** Имена берутся из самих данных, а строки таблиц адресуются по новым `data-tobacco-id` / `data-mix-id` (success criteria issue прямо разрешает `data-testid`).

Ни позиция, ни имя как якорь не работают, и это выяснилось на реальных данных:

- **имена не уникальны** — в снапшоте htreviews `1001 Nights` есть и у Layalina, и у Afzal; локатор по имени падает на strict mode violation;
- **позиция не стабильна** — сортировка по умолчанию «сначала по наличию» после батч-операции уводит строку в конец списка, а на каталоге из 11 505 позиций — вообще на другую страницу пагинации.

Поэтому результат батча читается по **счётчику чипа наличия** (не зависит ни от сортировки, ни от пагинации, ни от размера каталога), а возврат в наличие делается из отфильтрованного списка снятых.

**Сценарии на известных фикстурах выделены в отдельный проект** `master-seed-chromium` (`master-seed.spec.ts`): микс «Цитрусовый караван» в рейле «Свежая линия» и его состав из двух конкретных табаков. Предпосылка проверяется в самом тесте — если фикстур нет, сценарий помечается `skipped` с причиной, а не падает как UI-регрессия. Покрытие не ослаблено: батч-флоу инвентаря, редактор миксов, read-only рейлы и access-обсервабилити остались в общем прогоне.

**Учётки и daily code параметризованы** через `ATELIER_SMOKE_*` с дефолтами из seed.

**Про статистический рейл:** опора на «Больше всего выбирают» сохранена сознательно — это системное имя, backend синтезирует рейл на лету в `buildTopRail`, строкой в базе его нет.

## Находка про снапшот

`snapshots/atelier-product-data.dump` содержит **только каталог** — `Tobacco`, `Mix`, `MixComponent`, `Rail`, `RailMix`. Ни `StaffAccount`, ни `DailyAccessCode` в нём нет, поэтому на свежевосстановленной базе нельзя ни войти в консоль, ни пройти гостевой вход. Это зафиксировано в `docs/data/README.md` вместе с шагом `bootstrap:admin`, а `tests/smoke/README.md` описывает требования к состоянию базы, env-переменные и разбор проектов.

## Проверки

| Состояние базы | Результат |
|---|---|
| демо-seed (`npm run prisma:seed`) | **6 passed** — 3 прогона подряд |
| продуктовый снапшот (11 505 табаков, 15 миксов, 5 рейлов, отдельная БД + `bootstrap:admin`) | **4 passed + 2 skipped** — 4 прогона подряд |

Батч-тест отдельно прогнан 5 раз на снапшоте — 5/5 зелёных, и база после прогонов чистая (`SELECT count(*) FROM "Tobacco" WHERE NOT "inStock"` = 0): прогон неразрушающий.

Плюс `cd apps/master-web && npm test` (44 passed) и `npm run build` — правки разметки ограничены двумя `data-*` атрибутами.

## Побочная находка

Первые версии сценария использовали связку «поиск + фильтр наличия» и флакали примерно в половине прогонов. Причина — дефект приложения, а не теста: дебаунс поиска отправляет снимок фильтров, взятый до ввода, и запоздавший ответ откатывает только что выбранный `stock` (`App.tsx:450`, `nextFilters` из `inventoryFilters` в замыкании). Связка из smoke убрана, дефект заведён отдельно — #60.

## Вне scope

Содержимое снапшота и процедура пересборки, `prisma/seed.ts`, CI-воркфлоу `atelier-smoke` и его path-фильтры, продуктовое поведение обеих поверхностей.

🤖 Generated with [Claude Code](https://claude.com/claude-code)